### PR TITLE
triangle: Generate missing exercise README

### DIFF
--- a/exercises/triangle/README.md
+++ b/exercises/triangle/README.md
@@ -1,0 +1,52 @@
+# Triangle
+
+Determine if a triangle is equilateral, isosceles, or scalene.
+
+An _equilateral_ triangle has all three sides the same length.
+
+An _isosceles_ triangle has at least two sides the same length. (It is sometimes
+specified as having exactly two sides the same length, but for the purposes of
+this exercise we'll say at least two.)
+
+A _scalene_ triangle has all sides of different lengths.
+
+## Note
+
+For a shape to be a triangle at all, all sides have to be of length > 0, and
+the sum of the lengths of any two sides must be greater than or equal to the
+length of the third side. See [Triangle Inequality](https://en.wikipedia.org/wiki/Triangle_inequality).
+
+## Dig Deeper
+
+The case where the sum of the lengths of two sides _equals_ that of the
+third is known as a _degenerate_ triangle - it has zero area and looks like
+a single line. Feel free to add your own code/tests to check for degenerate triangles.
+
+## Setup
+
+Follow the setup instructions for Crystal here:
+
+http://exercism.io/languages/crystal
+
+More help installing can be found here:
+
+http://crystal-lang.org/docs/installation/index.html
+
+## Making the Test Suit Pass
+
+Execute the tests with:
+
+```bash
+$ crystal spec
+```
+
+In each test suite all but the first test have been skipped.
+
+Once you get a test passing, you can unskip the next one by changing `pending` to `it`.
+
+## Source
+
+The Ruby Koans triangle project, parts 1 & 2 [http://rubykoans.com](http://rubykoans.com)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.


### PR DESCRIPTION
In preparation for [v2](https://github.com/exercism/v2-feedback/blob/master/README.md) we're updating Configlet—our Exercism track linter—to require that we generate the exercise README. This is because in v2 we will not be generating READMEs on the fly, but deliver the README as defined in the directory for each implementation.

I'm going to go ahead and merge this as soon as the build passes, as this is janitorial work rather than a language-specific change.

See https://github.com/exercism/configlet/issues/116 for more details.