### PR TITLE
Mark difference_of_squares tests as pending

### DIFF
--- a/exercises/difference-of-squares/spec/difference_of_squares_spec.cr
+++ b/exercises/difference-of-squares/spec/difference_of_squares_spec.cr
@@ -6,39 +6,39 @@ describe "DifferenceOfSquares" do
     Squares.square_of_sum(5).should eq(225)
   end
 
-  it "calculates square of sum 10 is 3025" do
+  pending "calculates square of sum 10 is 3025" do
     Squares.square_of_sum(10).should eq(3025)
   end
 
-  it "calculates square of sum 100 is 25502500" do
+  pending "calculates square of sum 100 is 25502500" do
     Squares.square_of_sum(100).should eq(25502500)
   end
 
-  it "calculates sum of squares 5 is 55" do
+  pending "calculates sum of squares 5 is 55" do
     Squares.sum_of_squares(5).should eq(55)
   end
 
-  it "calculates sum of squares 10 is 385" do
+  pending "calculates sum of squares 10 is 385" do
     Squares.sum_of_squares(10).should eq(385)
   end
 
-  it "calculates sum of squares 100 is 338350" do
+  pending "calculates sum of squares 100 is 338350" do
     Squares.sum_of_squares(100).should eq(338350)
   end
 
-  it "calculates difference of squares 0 is 0" do
+  pending "calculates difference of squares 0 is 0" do
     Squares.difference_of_squares(0).should eq(0)
   end
 
-  it "calculates difference of squares 5 is 170" do
+  pending "calculates difference of squares 5 is 170" do
     Squares.difference_of_squares(5).should eq(170)
   end
 
-  it "calculates difference of squares 10 is 2640" do
+  pending "calculates difference of squares 10 is 2640" do
     Squares.difference_of_squares(10).should eq(2640)
   end
 
-  it "calculates difference of squares 100 is 25164150" do
+  pending "calculates difference of squares 100 is 25164150" do
     Squares.difference_of_squares(100).should eq(25164150)
   end
 end


### PR DESCRIPTION
In the majority of exercism crystal exercises all but the first test are marked as pending.
That was not the case for the exercise difference_of_squares.
This commit amends that exercise so it matches the rest.