### PR TITLE
trigger prerequisites from related make targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,5 @@ bin/generator
 cache/
 generator/lib
 generator/.shards
+generator/bin
 generator/bin/generator

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,6 @@ ci: bin/configlet
 	$(MAKE) test
 
 clean:
-	rm -rf bin/configlet $(GENERATORDIR)/{.shards,bin,cache,lib}
+	rm -rf bin/configlet $(addprefix $(GENERATORDIR)/,.shards bin cache lib)
 
 .PHONY: clean ci test test-generator build-generator test-exercise test-exercises generate-exercise generate-exercises

--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,8 @@ bin/configlet: bin/fetch-configlet
 	./bin/fetch-configlet
 
 ci: bin/configlet
-	./bin/configlet lint . || true  # FIXME: This fails locally for me. Is that expected?
-	$(MAKE) test
+	./bin/configlet lint . --track-id=crystal
+	$(MAKE) -s test
 
 clean:
 	rm -rf bin/configlet $(addprefix $(GENERATORDIR)/,.shards bin cache lib)

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ test-exercises:
 	@for exercise in $(EXERCISES); do EXERCISE=$$exercise $(MAKE) -s test-exercise || exit 1; done
 
 $(GENERATORBIN):
-	mkdir -p $@
+	@mkdir -p $@
 
 $(GENERATORBIN)/generator: $(G_SRCS) | $(GENERATORBIN)
 	@crystal build $(GENERATORDIR)/generator.$(FILEEXT) -o generator/bin/generator

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-EXERCISE ?= ""
 IGNOREDIRS := "^(\.git|.crystal|docs|bin|img|script)$$"
 EXERCISESDIR ?= "exercises"
 EXERCISES = $(shell find exercises -maxdepth 1 -mindepth 1 -type d | cut -d'/' -f2 | sort | grep -Ev $(IGNOREDIRS))
@@ -11,9 +10,12 @@ SPECFILE := "$(EXERCISENAME)_spec.$(FILEEXT)"
 SUPERSPECFILE := "$(SPECFILE).super"
 TMPSPECFILE := "$(SPECFILE).tmp"
 
-GENERATORDIR ?= "generator"
+GENERATORDIR ?= generator
+GENERATORBIN := $(GENERATORDIR)/bin
 GENERATORSDIR := $(GENERATORDIR)/src/generators
 GENERATORS = $(shell find $(GENERATORSDIR) -type f | cut -d '/' -f 4 | cut -d '.' -f 1 | sed 's/_/-/g')
+
+G_SRCS := $(shell find $(GENERATORDIR) -name "*.cr" -or -name "*.tt" | grep -Ev '(/lib/|/spec/)')
 
 test-exercise:
 	@echo "running formatting check for: $(EXERCISE)"
@@ -31,10 +33,15 @@ test-exercise:
 test-exercises:
 	@for exercise in $(EXERCISES); do EXERCISE=$$exercise $(MAKE) -s test-exercise || exit 1; done
 
-build-generator:
+$(GENERATORBIN):
+	mkdir -p $@
+
+$(GENERATORBIN)/generator: $(G_SRCS) | $(GENERATORBIN)
 	@crystal build $(GENERATORDIR)/generator.$(FILEEXT) -o generator/bin/generator
 
-generate-exercise:
+build-generator: $(GENERATORBIN)/generator
+
+generate-exercise: $(GENERATORBIN)/generator
 	@echo "generating spec file for generator: $(GENERATOR)"
 	@generator/bin/generator $(GENERATOR)
 
@@ -49,3 +56,15 @@ test:
 	@echo "running all the tests"
 	@$(MAKE) -s test-exercises
 	@$(MAKE) -s test-generator
+
+bin/configlet: bin/fetch-configlet
+	./bin/fetch-configlet
+
+ci: bin/configlet
+	./bin/configlet lint . || true  # FIXME: This fails locally for me. Is that expected?
+	$(MAKE) test
+
+clean:
+	rm -rf bin/configlet $(GENERATORDIR)/{.shards,bin,cache,lib}
+
+.PHONY: clean ci test test-generator build-generator test-exercise test-exercises generate-exercise generate-exercises

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ Exercism problems in Crystal.
 
 ### All Exercises
 
-Run all Exercises with:
+Test all exercises with:
 ```bash
 $ make test-exercises
 ```
 
 ### Single Exercises
 
-Run single Exercises with:
+Test single exercises with:
 ```bash
 $ make test-exercise EXERCISE=exercise-name
 ```
@@ -45,13 +45,14 @@ $ crystal generator/generator.cr hello-world
 
 Or build a binary and use that:
 ```bash
-$ make build-generator
 $ make generate-exercise GENERATOR=hello-world
 ```
 
+NOTE: A binary version of the generator is built automatically when needed for a given make target, but you may build it manually at any time by running `make build-generator` (or rebuild it with `make clean build-generator`).
+
 ### Running (or Re-running) the Generator for All Exercises
 
-This can be used for refreshing the tests when changes are made to the x-common repo. Or for testing the full functionality of the test generator.
+This can be used for refreshing the tests when changes are made to the [problem-specifications](https://github.com/exercism/problem-specifications) repo. Or for testing the full functionality of the test generator.
 
 ```bash
 $ make generate-exercises
@@ -62,6 +63,14 @@ $ make generate-exercises
 ```bash
 $ make test-generator
 ```
+
+### Cleaning up
+
+```bash
+$ make clean
+```
+
+Use this command to delete any transient files and build artifacts. This is potentially useful for troubleshooting purposes as it will purge any stale cached files, rebuild the generator when needed and can be combined with other make targets (e.g. `make clean test`).
 
 ## Contributing Guide
 


### PR DESCRIPTION
While attempting to figure out how to add an exercise, I noticed that some of the Makefile's build targets were not automatic (e.g. the generator build -> `generator/bin/generator`), so I added a few prerequisites and their corresponding targets, along with a helper target or two.

None of this is strictly necessary, of course. Please feel free to close this PR with impunity if you see fit.