### PR TITLE
Makefile: adjust GENERATORS definition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ TMPSPECFILE := "$(SPECFILE).tmp"
 GENERATORDIR ?= generator
 GENERATORBIN := $(GENERATORDIR)/bin
 GENERATORSDIR := $(GENERATORDIR)/src/generators
-GENERATORS = $(shell find $(GENERATORSDIR) -type f | cut -d '/' -f 4 | cut -d '.' -f 1 | sed 's/_/-/g')
+GENERATORS = $(shell find $(GENERATORSDIR) -name '*.cr' | xargs -I '{}' basename '{}' .cr | tr _ -)
 
 G_SRCS := $(shell find $(GENERATORDIR) -name "*.cr" -or -name "*.tt" | grep -Ev '(/lib/|/spec/)')
 


### PR DESCRIPTION
I was trying to understand how `GENERATORS` is computed, and I think this makes it a bit more readable – _find generator files, take their names and replace underscores with dashes_.

(Please do feel free to me know if this kind of changes is too trivial to bother you with!)

Cheers from ROSS conf! :tada: 