### PR TITLE
Update webmock to fix generator spec failure

### DIFF
--- a/generator/shard.lock
+++ b/generator/shard.lock
@@ -2,5 +2,5 @@ version: 1.0
 shards:
   webmock:
     github: manastech/webmock.cr
-    commit: c673f393a31eac2734c7599897357ef1f3f24011
+    commit: ca7c79ab3cc8b4c56cb1d70ba7a6952dc35ef8f6
 


### PR DESCRIPTION
Fixes #125 

Looks like there was a bug in webmock, seems like the bug was fixed though so just updating the dependency seems to have worked.