### PR TITLE
Fix typo in README template: Suit => Suite

### DIFF
--- a/config/exercise_readme.go.tmpl
+++ b/config/exercise_readme.go.tmpl
@@ -14,7 +14,7 @@ More help installing can be found here:
 
 http://crystal-lang.org/docs/installation/index.html
 
-## Making the Test Suit Pass
+## Making the Test Suite Pass
 
 Execute the tests with:
 

--- a/exercises/acronym/README.md
+++ b/exercises/acronym/README.md
@@ -17,7 +17,7 @@ More help installing can be found here:
 
 http://crystal-lang.org/docs/installation/index.html
 
-## Making the Test Suit Pass
+## Making the Test Suite Pass
 
 Execute the tests with:
 

--- a/exercises/anagram/README.md
+++ b/exercises/anagram/README.md
@@ -16,7 +16,7 @@ More help installing can be found here:
 
 http://crystal-lang.org/docs/installation/index.html
 
-## Making the Test Suit Pass
+## Making the Test Suite Pass
 
 Execute the tests with:
 

--- a/exercises/armstrong-numbers/README.md
+++ b/exercises/armstrong-numbers/README.md
@@ -21,7 +21,7 @@ More help installing can be found here:
 
 http://crystal-lang.org/docs/installation/index.html
 
-## Making the Test Suit Pass
+## Making the Test Suite Pass
 
 Execute the tests with:
 

--- a/exercises/atbash-cipher/README.md
+++ b/exercises/atbash-cipher/README.md
@@ -38,7 +38,7 @@ More help installing can be found here:
 
 http://crystal-lang.org/docs/installation/index.html
 
-## Making the Test Suit Pass
+## Making the Test Suite Pass
 
 Execute the tests with:
 

--- a/exercises/binary-search-tree/README.md
+++ b/exercises/binary-search-tree/README.md
@@ -63,7 +63,7 @@ More help installing can be found here:
 
 http://crystal-lang.org/docs/installation/index.html
 
-## Making the Test Suit Pass
+## Making the Test Suite Pass
 
 Execute the tests with:
 

--- a/exercises/binary/README.md
+++ b/exercises/binary/README.md
@@ -40,7 +40,7 @@ More help installing can be found here:
 
 http://crystal-lang.org/docs/installation/index.html
 
-## Making the Test Suit Pass
+## Making the Test Suite Pass
 
 Execute the tests with:
 

--- a/exercises/bob/README.md
+++ b/exercises/bob/README.md
@@ -25,7 +25,7 @@ More help installing can be found here:
 
 http://crystal-lang.org/docs/installation/index.html
 
-## Making the Test Suit Pass
+## Making the Test Suite Pass
 
 Execute the tests with:
 

--- a/exercises/bracket-push/README.md
+++ b/exercises/bracket-push/README.md
@@ -14,7 +14,7 @@ More help installing can be found here:
 
 http://crystal-lang.org/docs/installation/index.html
 
-## Making the Test Suit Pass
+## Making the Test Suite Pass
 
 Execute the tests with:
 

--- a/exercises/collatz-conjecture/README.md
+++ b/exercises/collatz-conjecture/README.md
@@ -36,7 +36,7 @@ More help installing can be found here:
 
 http://crystal-lang.org/docs/installation/index.html
 
-## Making the Test Suit Pass
+## Making the Test Suite Pass
 
 Execute the tests with:
 

--- a/exercises/difference-of-squares/README.md
+++ b/exercises/difference-of-squares/README.md
@@ -26,7 +26,7 @@ More help installing can be found here:
 
 http://crystal-lang.org/docs/installation/index.html
 
-## Making the Test Suit Pass
+## Making the Test Suite Pass
 
 Execute the tests with:
 

--- a/exercises/flatten-array/README.md
+++ b/exercises/flatten-array/README.md
@@ -20,7 +20,7 @@ More help installing can be found here:
 
 http://crystal-lang.org/docs/installation/index.html
 
-## Making the Test Suit Pass
+## Making the Test Suite Pass
 
 Execute the tests with:
 

--- a/exercises/forth/README.md
+++ b/exercises/forth/README.md
@@ -35,7 +35,7 @@ More help installing can be found here:
 
 http://crystal-lang.org/docs/installation/index.html
 
-## Making the Test Suit Pass
+## Making the Test Suite Pass
 
 Execute the tests with:
 

--- a/exercises/gigasecond/README.md
+++ b/exercises/gigasecond/README.md
@@ -15,7 +15,7 @@ More help installing can be found here:
 
 http://crystal-lang.org/docs/installation/index.html
 
-## Making the Test Suit Pass
+## Making the Test Suite Pass
 
 Execute the tests with:
 

--- a/exercises/hamming/README.md
+++ b/exercises/hamming/README.md
@@ -33,7 +33,7 @@ More help installing can be found here:
 
 http://crystal-lang.org/docs/installation/index.html
 
-## Making the Test Suit Pass
+## Making the Test Suite Pass
 
 Execute the tests with:
 

--- a/exercises/hello-world/README.md
+++ b/exercises/hello-world/README.md
@@ -58,7 +58,7 @@ More help installing can be found here:
 
 http://crystal-lang.org/docs/installation/index.html
 
-## Making the Test Suit Pass
+## Making the Test Suite Pass
 
 Execute the tests with:
 

--- a/exercises/isbn-verifier/README.md
+++ b/exercises/isbn-verifier/README.md
@@ -50,7 +50,7 @@ More help installing can be found here:
 
 http://crystal-lang.org/docs/installation/index.html
 
-## Making the Test Suit Pass
+## Making the Test Suite Pass
 
 Execute the tests with:
 

--- a/exercises/isogram/README.md
+++ b/exercises/isogram/README.md
@@ -23,7 +23,7 @@ More help installing can be found here:
 
 http://crystal-lang.org/docs/installation/index.html
 
-## Making the Test Suit Pass
+## Making the Test Suite Pass
 
 Execute the tests with:
 

--- a/exercises/largest-series-product/README.md
+++ b/exercises/largest-series-product/README.md
@@ -23,7 +23,7 @@ More help installing can be found here:
 
 http://crystal-lang.org/docs/installation/index.html
 
-## Making the Test Suit Pass
+## Making the Test Suite Pass
 
 Execute the tests with:
 

--- a/exercises/leap/README.md
+++ b/exercises/leap/README.md
@@ -33,7 +33,7 @@ More help installing can be found here:
 
 http://crystal-lang.org/docs/installation/index.html
 
-## Making the Test Suit Pass
+## Making the Test Suite Pass
 
 Execute the tests with:
 

--- a/exercises/pangram/README.md
+++ b/exercises/pangram/README.md
@@ -18,7 +18,7 @@ More help installing can be found here:
 
 http://crystal-lang.org/docs/installation/index.html
 
-## Making the Test Suit Pass
+## Making the Test Suite Pass
 
 Execute the tests with:
 

--- a/exercises/pascals-triangle/README.md
+++ b/exercises/pascals-triangle/README.md
@@ -24,7 +24,7 @@ More help installing can be found here:
 
 http://crystal-lang.org/docs/installation/index.html
 
-## Making the Test Suit Pass
+## Making the Test Suite Pass
 
 Execute the tests with:
 

--- a/exercises/raindrops/README.md
+++ b/exercises/raindrops/README.md
@@ -27,7 +27,7 @@ More help installing can be found here:
 
 http://crystal-lang.org/docs/installation/index.html
 
-## Making the Test Suit Pass
+## Making the Test Suite Pass
 
 Execute the tests with:
 

--- a/exercises/react/README.md
+++ b/exercises/react/README.md
@@ -25,7 +25,7 @@ More help installing can be found here:
 
 http://crystal-lang.org/docs/installation/index.html
 
-## Making the Test Suit Pass
+## Making the Test Suite Pass
 
 Execute the tests with:
 

--- a/exercises/reverse-string/README.md
+++ b/exercises/reverse-string/README.md
@@ -16,7 +16,7 @@ More help installing can be found here:
 
 http://crystal-lang.org/docs/installation/index.html
 
-## Making the Test Suit Pass
+## Making the Test Suite Pass
 
 Execute the tests with:
 

--- a/exercises/rna-transcription/README.md
+++ b/exercises/rna-transcription/README.md
@@ -28,7 +28,7 @@ More help installing can be found here:
 
 http://crystal-lang.org/docs/installation/index.html
 
-## Making the Test Suit Pass
+## Making the Test Suite Pass
 
 Execute the tests with:
 

--- a/exercises/roman-numerals/README.md
+++ b/exercises/roman-numerals/README.md
@@ -52,7 +52,7 @@ More help installing can be found here:
 
 http://crystal-lang.org/docs/installation/index.html
 
-## Making the Test Suit Pass
+## Making the Test Suite Pass
 
 Execute the tests with:
 

--- a/exercises/run-length-encoding/README.md
+++ b/exercises/run-length-encoding/README.md
@@ -33,7 +33,7 @@ More help installing can be found here:
 
 http://crystal-lang.org/docs/installation/index.html
 
-## Making the Test Suit Pass
+## Making the Test Suite Pass
 
 Execute the tests with:
 

--- a/exercises/scrabble-score/README.md
+++ b/exercises/scrabble-score/README.md
@@ -49,7 +49,7 @@ More help installing can be found here:
 
 http://crystal-lang.org/docs/installation/index.html
 
-## Making the Test Suit Pass
+## Making the Test Suite Pass
 
 Execute the tests with:
 

--- a/exercises/sieve/README.md
+++ b/exercises/sieve/README.md
@@ -39,7 +39,7 @@ More help installing can be found here:
 
 http://crystal-lang.org/docs/installation/index.html
 
-## Making the Test Suit Pass
+## Making the Test Suite Pass
 
 Execute the tests with:
 

--- a/exercises/space-age/README.md
+++ b/exercises/space-age/README.md
@@ -27,7 +27,7 @@ More help installing can be found here:
 
 http://crystal-lang.org/docs/installation/index.html
 
-## Making the Test Suit Pass
+## Making the Test Suite Pass
 
 Execute the tests with:
 

--- a/exercises/triangle/README.md
+++ b/exercises/triangle/README.md
@@ -32,7 +32,7 @@ More help installing can be found here:
 
 http://crystal-lang.org/docs/installation/index.html
 
-## Making the Test Suit Pass
+## Making the Test Suite Pass
 
 Execute the tests with:
 

--- a/exercises/two-fer/README.md
+++ b/exercises/two-fer/README.md
@@ -35,7 +35,7 @@ More help installing can be found here:
 
 http://crystal-lang.org/docs/installation/index.html
 
-## Making the Test Suit Pass
+## Making the Test Suite Pass
 
 Execute the tests with:
 


### PR DESCRIPTION
- This hasn't been applied to all the exercise READMEs as I couldn't find an obvious command to re-generate the contents from this template? If "apply the changes manually" is how things work, I'm happy to do that too.

Many thanks for maintaining these exercises!