### PR TITLE
triangle: expect new to raise ArgumentError if invalid

### DIFF
--- a/exercises/triangle/spec/triangle_spec.cr
+++ b/exercises/triangle/spec/triangle_spec.cr
@@ -15,7 +15,9 @@ describe "Triangle" do
   end
 
   pending "all zero sides is not a triangle" do
-    Triangle.new({0, 0, 0}).equilateral?.should eq(false)
+    expect_raises(ArgumentError) do
+      Triangle.new({0, 0, 0})
+    end
   end
 
   pending "sides may be floats" do
@@ -43,15 +45,21 @@ describe "Triangle" do
   end
 
   pending "first triangle inequality violation" do
-    Triangle.new({1, 1, 3}).isosceles?.should eq(false)
+    expect_raises(ArgumentError) do
+      Triangle.new({1, 1, 3})
+    end
   end
 
   pending "second triangle inequality violation" do
-    Triangle.new({1, 3, 1}).isosceles?.should eq(false)
+    expect_raises(ArgumentError) do
+      Triangle.new({1, 3, 1})
+    end
   end
 
   pending "third triangle inequality violation" do
-    Triangle.new({3, 1, 1}).isosceles?.should eq(false)
+    expect_raises(ArgumentError) do
+      Triangle.new({3, 1, 1})
+    end
   end
 
   pending "sides may be floats" do
@@ -71,7 +79,9 @@ describe "Triangle" do
   end
 
   pending "may not violate triangle inequality" do
-    Triangle.new({7, 3, 2}).scalene?.should eq(false)
+    expect_raises(ArgumentError) do
+      Triangle.new({7, 3, 2})
+    end
   end
 
   pending "sides may be floats" do

--- a/exercises/triangle/src/example.cr
+++ b/exercises/triangle/src/example.cr
@@ -3,7 +3,7 @@ class Triangle
 
   def initialize(sides : Tuple(Int32, Int32, Int32) | Tuple(Float64, Float64, Float64))
     @sides = sides.to_a
-    @sides = [] of Int32 if illegal?
+    raise ArgumentError.new("illegal triangle") if illegal?
   end
 
   def equilateral?

--- a/generator/src/generators/triangle.cr
+++ b/generator/src/generators/triangle.cr
@@ -20,6 +20,11 @@ class TriangleTestCase < ExerciseTestCase
     def to_s(io)
       io << "{#{sides.map { |s| s.to_i == s.to_f ? s.to_i : s.to_s }.join(", ")}}"
     end
+
+    def valid_triangle?
+      sorted_sides = sides.to_a.sort
+      sides.all?(&.>(0)) && sorted_sides.last < sorted_sides.first(2).sum
+    end
   end
 
   JSON.mapping(
@@ -30,7 +35,15 @@ class TriangleTestCase < ExerciseTestCase
   )
 
   def workload
-    "Triangle.new(#{input}).#{property}?.should eq(#{expected})"
+    if input.valid_triangle?
+      "Triangle.new(#{input}).#{property}?.should eq(#{expected})"
+    else
+      <<-WL
+      expect_raises(ArgumentError) do
+            Triangle.new(#{input})
+          end
+      WL
+    end
   end
 
   def test_name


### PR DESCRIPTION
Under the principle of failing fast, the author of this commit would
like to argue that it is better design to have the constructor report
when a triangle is invalid, rather than create a Triangle object that is
not actually a triangle, and have the client of the triangle receive
nasty surprises down the road.

This was attempted to be submitted to problem-specifications as
https://github.com/exercism/problem-specifications/pull/1590
however the author realised that it was not possible to justify making
this an error in the canonical-data.json since it directs each track to
make its own decisions about invalid triangles.

Thus it seems it has to be a track-specific decision. Since the Crystal
track is taking the "construct a triangle" route (`Triangle.new`), there
is the possibility of `new` failing.