### PR TITLE
generators/triangle: use JSON::Any#as_i? to format ints/floats

### DIFF
--- a/generator/src/generators/triangle.cr
+++ b/generator/src/generators/triangle.cr
@@ -14,11 +14,11 @@ end
 class TriangleTestCase < ExerciseTestCase
   class Input
     JSON.mapping(
-      sides: Tuple(Int32, Int32, Int32) | Tuple(Float64, Float64, Float64)
+      sides: Tuple(JSON::Any, JSON::Any, JSON::Any)
     )
 
     def to_s(io)
-      io << "{#{sides.map { |s| s.to_i == s.to_f ? s.to_i : s.to_s }.join(", ")}}"
+      io << "{#{sides.map { |s| s.as_i? || s.as_f }.join(", ")}}"
     end
   end
 


### PR DESCRIPTION
This used to be more interesting before
https://github.com/exercism/crystal/pull/186.
    
Now it's not really useful, but does still generate the same tests.
    
Before this can be merged, it requires justification for why this way
should be used instead of the existing way.
