### PR TITLE
meetup: Time.utc

### DIFF
--- a/exercises/practice/meetup/.meta/src/example.cr
+++ b/exercises/practice/meetup/.meta/src/example.cr
@@ -13,7 +13,7 @@ module Meetup
   DAYS_IN_WEEK = 7
 
   def meetup(year : Number, month : Number, week : String, day_of_week : String) : String
-    time = Time.new(year, month, START_DAYS[week])
+    time = Time.utc(year, month, START_DAYS[week])
     day = Time::DayOfWeek.parse(day_of_week).to_i
 
     if (week == "last")


### PR DESCRIPTION
Time.new with those particular args removed in 0.33.0 (2020-02-14)

See https://github.com/exercism/crystal/pull/194 - all four PRs are required for build to pass again:

* https://github.com/exercism/crystal/pull/195
* https://github.com/exercism/crystal/pull/196
* https://github.com/exercism/crystal/pull/197
* https://github.com/exercism/crystal/pull/198

