### PR TITLE
crystal tool format

### DIFF
--- a/exercises/bob/spec/bob_spec.cr
+++ b/exercises/bob/spec/bob_spec.cr
@@ -16,11 +16,11 @@ describe "Bob" do
     end
 
     pending "responds to talking forcefully" do
-      Bob.hey("Let\'s go make out behind the gym!").should eq "Whatever."
+      Bob.hey("Let's go make out behind the gym!").should eq "Whatever."
     end
 
     pending "responds to using acronyms in regular speech" do
-      Bob.hey("It\'s OK if you don\'t want to go to the DMV.").should eq "Whatever."
+      Bob.hey("It's OK if you don't want to go to the DMV.").should eq "Whatever."
     end
 
     pending "responds to forceful questions" do

--- a/generator/src/generators/binary.cr
+++ b/generator/src/generators/binary.cr
@@ -31,7 +31,7 @@ class BinaryTestCase < ExerciseTestCase
     else
       <<-WL
       expect_raises(ArgumentError) do
-            Binary.to_decimal(\"#{input.binary}\")
+            Binary.to_decimal("#{input.binary}")
           end
       WL
     end

--- a/generator/src/generators/hamming.cr
+++ b/generator/src/generators/hamming.cr
@@ -36,7 +36,7 @@ class HammingTestCase < ExerciseTestCase
     if expected.is_a?(Error)
       <<-WL
       expect_raises(ArgumentError) do
-            Hamming.#{property}(\"#{input.strand1}\", \"#{input.strand2}\")
+            Hamming.#{property}("#{input.strand1}", "#{input.strand2}")
           end
       WL
     else

--- a/generator/src/generators/series.cr
+++ b/generator/src/generators/series.cr
@@ -36,7 +36,7 @@ class SeriesTestCase < ExerciseTestCase
     if expected.is_a?(Error)
       <<-WL
       expect_raises(ArgumentError) do
-            Series.#{property}(\"#{input.series}\", #{input.sliceLength})
+            Series.#{property}("#{input.series}", #{input.sliceLength})
           end
       WL
     else


### PR DESCRIPTION
A few unnecessary backslashes are removed.

bob
binary
hamming
series

It's been confirmed that running all these generators produces no
changes, so it's safe to remove these backslashes with no further
changes.

```sh
for x in bob binary hamming series; do crystal run ./generator/generator.cr -- $x; done
```


See https://github.com/exercism/crystal/pull/194 - all four PRs are required for build to pass again:

* https://github.com/exercism/crystal/pull/195
* https://github.com/exercism/crystal/pull/196
* https://github.com/exercism/crystal/pull/197
* https://github.com/exercism/crystal/pull/198