### PR TITLE
matching-brackets: escape backslashes in input string; set all but first to pending

### DIFF
--- a/exercises/practice/matching-brackets/spec/matching_brackets_spec.cr
+++ b/exercises/practice/matching-brackets/spec/matching_brackets_spec.cr
@@ -67,6 +67,6 @@ describe "MatchingBrackets" do
   end
 
   pending "complex latex expression" do
-    MatchingBrackets.valid?("\left(\begin{array}{cc} \frac{1}{3} & x\\ \mathrm{e}^{x} &... x^2 \end{array}\right)").should eq(true)
+    MatchingBrackets.valid?("\\left(\\begin{array}{cc} \\frac{1}{3} & x\\\\ \\mathrm{e}^{x} &... x^2 \\end{array}\\right)").should eq(true)
   end
 end

--- a/exercises/practice/matching-brackets/spec/matching_brackets_spec.cr
+++ b/exercises/practice/matching-brackets/spec/matching_brackets_spec.cr
@@ -6,67 +6,67 @@ describe "MatchingBrackets" do
     MatchingBrackets.valid?("[]").should eq(true)
   end
 
-  it "empty string" do
+  pending "empty string" do
     MatchingBrackets.valid?("").should eq(true)
   end
 
-  it "unpaired brackets" do
+  pending "unpaired brackets" do
     MatchingBrackets.valid?("[[").should eq(false)
   end
 
-  it "wrong ordered brackets" do
+  pending "wrong ordered brackets" do
     MatchingBrackets.valid?("}{").should eq(false)
   end
 
-  it "wrong closing bracket" do
+  pending "wrong closing bracket" do
     MatchingBrackets.valid?("{]").should eq(false)
   end
 
-  it "paired with whitespace" do
+  pending "paired with whitespace" do
     MatchingBrackets.valid?("{ }").should eq(true)
   end
 
-  it "partially paired brackets" do
+  pending "partially paired brackets" do
     MatchingBrackets.valid?("{[])").should eq(false)
   end
 
-  it "simple nested brackets" do
+  pending "simple nested brackets" do
     MatchingBrackets.valid?("{[]}").should eq(true)
   end
 
-  it "several paired brackets" do
+  pending "several paired brackets" do
     MatchingBrackets.valid?("{}[]").should eq(true)
   end
 
-  it "paired and nested brackets" do
+  pending "paired and nested brackets" do
     MatchingBrackets.valid?("([{}({}[])])").should eq(true)
   end
 
-  it "unopened closing brackets" do
+  pending "unopened closing brackets" do
     MatchingBrackets.valid?("{[)][]}").should eq(false)
   end
 
-  it "unpaired and nested brackets" do
+  pending "unpaired and nested brackets" do
     MatchingBrackets.valid?("([{])").should eq(false)
   end
 
-  it "paired and wrong nested brackets" do
+  pending "paired and wrong nested brackets" do
     MatchingBrackets.valid?("[({]})").should eq(false)
   end
 
-  it "paired and incomplete brackets" do
+  pending "paired and incomplete brackets" do
     MatchingBrackets.valid?("{}[").should eq(false)
   end
 
-  it "too many closing brackets" do
+  pending "too many closing brackets" do
     MatchingBrackets.valid?("[]]").should eq(false)
   end
 
-  it "math expression" do
+  pending "math expression" do
     MatchingBrackets.valid?("(((185 + 223.85) * 15) - 543)/2").should eq(true)
   end
 
-  it "complex latex expression" do
+  pending "complex latex expression" do
     MatchingBrackets.valid?("\left(\begin{array}{cc} \frac{1}{3} & x\\ \mathrm{e}^{x} &... x^2 \end{array}\right)").should eq(true)
   end
 end

--- a/generator/src/generators/matching_brackets.cr
+++ b/generator/src/generators/matching_brackets.cr
@@ -26,7 +26,8 @@ class MatchingBracketsTestCase < ExerciseTestCase
   )
 
   def workload
-    "MatchingBrackets.valid?(\"#{input.value}\").should eq(#{expected})"
+    # Must inspect - some inputs have backslashes that need to be escaped
+    "MatchingBrackets.valid?(#{input.value.inspect}).should eq(#{expected})"
   end
 
   def test_name


### PR DESCRIPTION
It's necessary to do this because one input has backslashes in it, and
not escaping them means that they are treated as escape sequences along
with the character immediately following them.

That would cause the generator and `crystal tool format` to disagree on
what the spec should look like. The formatter will remove the backslash
before `\left` and `\mathrm` because `\l` and `\m` are not escape
sequences listed in
https://crystal-lang.org/reference/syntax_and_semantics/literals/string.html

It's admitted that the presence/absence of the backslashes is immaterial
to this problem, since the backslash is not a bracket character that is
being checked for pairedness.

However, failure to escape the backslashes angers those who know LaTeX
because then the string is no longer valid LaTeX.

Therefore, it is better to escape them.

Notice how in the JSON file, it was also necessary to escape the
backslashes.
https://github.com/exercism/problem-specifications/tree/master/exercises/matching-brackets

See https://github.com/exercism/crystal/pull/194 - all four PRs are required for build to pass again:

* https://github.com/exercism/crystal/pull/195
* https://github.com/exercism/crystal/pull/196
* https://github.com/exercism/crystal/pull/197
* https://github.com/exercism/crystal/pull/198