### PR TITLE
binary-search-tree: fix test for deleting root node

### DIFF
--- a/exercises/practice/binary-search-tree/spec/binary_search_tree_spec.cr
+++ b/exercises/practice/binary-search-tree/spec/binary_search_tree_spec.cr
@@ -79,6 +79,7 @@ describe "BinarySearchTree" do
       tree.insert(2)
       tree.delete(5)
       tree.value.should eq(2)
+      tree.left.should be_nil
     end
 
     pending "removes a node with no children" do


### PR DESCRIPTION
In the moment it is possible to pass the tests even if the deletion of the root node is not handled correctly.
One part is that the value of the root node is replaced but we also need to make sure that the node the value comes from is actually deleted from the tree.  
Let me explain a bit more what I mean.

In the particular test case, we construct a tree that looks like:
```
  5
 / 
2 
```

Now we delete `5` and want to obtain
```
  2
```

But we currently do not check if we may obtain something like:
```
  2
 /
2
```

I admit that this may not be an obvious case but since this happened to a student I'm currently mentoring, I thought that it may be useful to add this check to the test case.

Let me know what you think :)