### PR TITLE
[v3] Update Markdown files to latest spec

### DIFF
--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,3 +1,5 @@
+# About
+
 Crystal is a compiled language that is currently in the alpha stages of development. 
 These are some of the language's goals:
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,4 +1,4 @@
-## Installation
+# Installation
 
 *Note: Currently, Crystal only supports Linux and OSX.*
 

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,4 +1,4 @@
-## Learning Crystal
+# Learning Crystal
 
 * [Crystal Official Docs](https://crystal-lang.org/docs/): This is the go-to learning resource for Crystal at the moment. And they are pretty exhaustive, right from the basic literals and variables to some advanced stuff like macros. They also have a neat [doc on coding conventions](https://crystal-lang.org/docs/conventions/index.html).
 

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,3 +1,3 @@
-## Recommended References
+# Recommended References
 
 * [Crystal API](http://crystal-lang.org/api/)

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,3 +1,5 @@
+# Tests
+
 ## Running Tests
 
 When you are in the directory for an exercise, you should see two subdirectories:

--- a/exercises/practice/hello-world/.docs/instructions.append.md
+++ b/exercises/practice/hello-world/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 ## Project Structure
 
 * `src` contains your solution to the exercise


### PR DESCRIPTION
We've defined a [specification for Markdown files](https://github.com/exercism/docs/blob/main/contributing/standards/markdown.md) to be applied Exercism-wide. This standard includes, amongst others, the following two rules:

- All files must start start with a level-1 heading (`# Some heading text`)
- No heading may decend a level greater than one below the previous (e.g. `## may only be followed by ###, not ####`)

This PR applies the above two rules to the Markdown documents in this repo. 

## Tracking

https://github.com/exercism/v3-launch/issues/17
