### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,32 @@
+{
+  "docs": [
+    {
+      "uuid": "b1e7de5a-371d-4b11-b2f8-8bfc58b6eca8",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing Crystal locally",
+      "blurb": "Learn how to install Crystal locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "3ef9fe1c-43a0-43d0-b40d-56f39bf219ec",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn Crystal",
+      "blurb": "An overview of how to get started from scratch with Crystal"
+    },
+    {
+      "uuid": "c52b4d43-3a68-49d2-af37-e74e7e047df0",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the Crystal track",
+      "blurb": "Learn how to test your Crystal exercises on Exercism"
+    },
+    {
+      "uuid": "f8fe3ce0-9481-42dc-b8ba-a0e3dedb00db",
+      "slug": "resources",
+      "path": "docs/RESOURCES.md",
+      "title": "Useful Crystal resources",
+      "blurb": "A collection of useful resources to help you master Crystal"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
