### PR TITLE
Fix link to installation guides

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -2,4 +2,4 @@
 
 *Note: Currently, Crystal only supports Linux and OSX.*
 
-Use one of the [installation guides](http://crystal-lang.org/docs/installation/index.html) for instructions on installing Crystal.
+Use one of the [installation guides](https://crystal-lang.org/install/) for instructions on installing Crystal.


### PR DESCRIPTION
Corrects a broken link (404) to installation guides in INSTALLATION.md

**Current**
https://crystal-lang.org/reference/installation/index.html

**New**
https://crystal-lang.org/install/
