### PR TITLE
🤖 Fix invalid UUIDs

### DIFF
--- a/config.json
+++ b/config.json
@@ -497,7 +497,7 @@
       {
         "slug": "protein-translation",
         "name": "Protein Translation",
-        "uuid": "00c6f623-2e54-4f90-ae3f-07e493f93c7c",
+        "uuid": "718711b2-16d5-4d50-9fe1-a62135ced606",
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
@@ -523,7 +523,7 @@
       {
         "slug": "allergies",
         "name": "Allergies",
-        "uuid": "b306bdaa-438e-46a2-ba54-82cb2c0be882",
+        "uuid": "6c07e00f-78f0-4878-9222-d9e3ed86fd0b",
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,


### PR DESCRIPTION
This PR regenerates each UUID on the track that was invalid.

To be valid, each value of a `uuid` key must:
- Be a well-formed version 4 UUID (compliant with RFC 4122) in the
  canonical textual representation [1]
- Not exist elsewhere on the track
- Not exist elsewhere on Exercism

A track can generate a suitable UUID by running `configlet uuid`.

In the future, `configlet lint` will produce an error for an invalid
UUID.

[1] That is, it must match this regular expression:
```
^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$
```

## Tracking

https://github.com/exercism/v3-launch/issues/29
