### PR TITLE
Add icons for key features

### DIFF
--- a/config.json
+++ b/config.json
@@ -607,32 +607,32 @@
     {
       "title": "Simple Syntax",
       "content": "Crystal's syntax is heavily inspired by Ruby, so it is natural to read and easy to write.",
-      "icon": "TODO"
+      "icon": "fun"
     },
     {
       "title": "Static Type Checking",
       "content": "Crystal is statically type checked with built-in type inference, so type errors are caught early.",
-      "icon": "TODO"
+      "icon": "immutable"
     },
     {
       "title": "Null Reference Checks",
       "content": "All types are non-nilable in Crystal, so the compiler checks for null references at compile time.",
-      "icon": "TODO"
+      "icon": "safe"
     },
     {
       "title": "Concurrency Model",
       "content": "Crystal has built in concurrency primitives, called fibers, to achieve concurrency.",
-      "icon": "TODO"
+      "icon": "concurrency"
     },
     {
       "title": "C-Interopability",
       "content": "Crystal has dedicated syntax to easily call native libraries, increasing code re-use.",
-      "icon": "TODO"
+      "icon": "interop"
     },
     {
       "title": "Macros",
       "content": "Crystal's answer to metaprogramming is a powerful macro system.",
-      "icon": "TODO"
+      "icon": "powerful"
     }
   ],
   "tags": [


### PR DESCRIPTION
The icons for key features are now available, and `configlet lint` now requires that each key feature has a valid `icon` value.

This PR sets an initial icon for each key feature - feel free to change them however you want. You can see the list of available icons [here](https://github.com/exercism/docs/issues/189). Note that an icon can be used regardless of its name.

With the initial state of this PR, the key features look something like the below.

---

![fun](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/fun.svg) Simple Syntax
Crystal's syntax is heavily inspired by Ruby, so it is natural to read and easy to write.

![immutable](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/immutable.svg) Static Type Checking
Crystal is statically type checked with built-in type inference, so type errors are caught early.

![safe](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/safe.svg) Null Reference Checks
All types are non-nilable in Crystal, so the compiler checks for null references at compile time.

![concurrency](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/concurrency.svg) Concurrency Model
Crystal has built in concurrency primitives, called fibers, to achieve concurrency.

![interop](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/interop.svg) C-Interopability
Crystal has dedicated syntax to easily call native libraries, increasing code re-use.

![powerful](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/powerful.svg) Macros
Crystal's answer to metaprogramming is a powerful macro system.
