### PR TITLE
sieve: specify stepping by 1

### DIFF
--- a/exercises/practice/sieve/.meta/src/example.cr
+++ b/exercises/practice/sieve/.meta/src/example.cr
@@ -5,7 +5,7 @@ module Primes
     sieve_ar = Array.new(limit + 1, true)
     sieve_ar[0] = sieve_ar[1] = false
 
-    2.step(to: Math.sqrt(limit)) do |i|
+    2.step(to: Math.sqrt(limit), by: 1) do |i|
       next unless sieve_ar[i]
       (i*i).step(to: limit, by: i) { |ii| sieve_ar[ii] = false }
     end


### PR DESCRIPTION
If not, then for limit 1, this will crash, because `2.step(to: 1)` will
access `sieve_ar[2]` for an array with two elements, which is out of
bounds.

This must be a (relatively) recent change to #step. Perhaps the changes
listed in 0.36.0 in
https://github.com/crystal-lang/crystal/blob/master/CHANGELOG.md

Previously, it didn't crash because `2.step(to: 1)` was just an empty
iteration. However, in trying to be smart with auto-detecting the
iteration detection, they broke code that implicitly depended on
iteration direction always being positive instead of being
auto-detected.