### PR TITLE
Makefile: ignore shared

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-IGNOREDIRS := "^(\.git|.crystal|docs|bin|img|script)$$"
+IGNOREDIRS := "^shared/"
 EXERCISESDIR ?= "exercises"
 EXERCISES = $(shell find exercises -maxdepth 2 -mindepth 2 -type d | cut -d'/' -f2-3 | sort | grep -Ev $(IGNOREDIRS))
 


### PR DESCRIPTION
Otherwise, it will try to test shared/.docs as an exercise, when it
isn't one.

All other items in IGNOREDIRS can go away because none of those
directories are directories under exercises