### PR TITLE
Fix whitespace in test generator

### DIFF
--- a/generator/src/exercise_generator.cr
+++ b/generator/src/exercise_generator.cr
@@ -45,5 +45,5 @@ abstract class ExerciseGenerator
     end
   end
 
-  ECR.def_to_s "#{__DIR__}/templates/example.tt"
+  ECR.def_to_s "#{__DIR__}/templates/example.ecr"
 end

--- a/generator/src/templates/example.ecr
+++ b/generator/src/templates/example.ecr
@@ -3,10 +3,10 @@ require "../src/*"
 
 describe <%= "#{describe_name.inspect} do" -%>
 <% test_cases.each_with_index do |test_case, index| %>
-  <%= test_case.pending?(index) %> "<%= test_case.test_name %>" do <% -%>
-    <% test_case.workload.split("\n").each do |line| %>
+  <%= test_case.pending?(index) %> "<%= test_case.test_name %>" do<%- -%>
+    <%- test_case.workload.split("\n").each do |line| %>
     <%= line -%>
-    <% end %>
+    <%- end %>
   end
 <% end -%>
 end


### PR DESCRIPTION
Trailing whitespace was being generated by the template.
Add the appropriate ECR syntax to remove it.

Also, switch template file from 'tt' to 'ecr'