### PR TITLE
Configure online editor to use 2 space indents

### DIFF
--- a/config.json
+++ b/config.json
@@ -12,7 +12,7 @@
   "version": 3,
   "online_editor": {
     "indent_style": "space",
-    "indent_size": 4,
+    "indent_size": 2,
     "highlightjs_language": "crystal"
   },
   "test_runner": {


### PR DESCRIPTION
Indenting with two spaces is the convention according to the coding style guide on the official Crystal-lang website (https://crystal-lang.org/reference/1.5/conventions/coding_style.html).

Closes #203 