### PR TITLE
[Fix-generator]: Make all keys in json lower cased

### DIFF
--- a/bin/generator_help.cr
+++ b/bin/generator_help.cr
@@ -73,9 +73,7 @@ class GeneratorHelp
     if obj.as_h?
       json_obj = {} of String => JSON::Any
       obj.as_h.each do |key, value|
-        unless value == nil
-          json_obj[key.downcase] = lowercase_keys(value)
-        end
+        json_obj[key.downcase] = lowercase_keys(value)
       end
       JSON::Any.new(json_obj)
     elsif obj.as_a?

--- a/bin/generator_help.cr
+++ b/bin/generator_help.cr
@@ -60,12 +60,32 @@ class GeneratorHelp
     response = HTTP::Client.get("https://raw.githubusercontent.com/exercism/problem-specifications/main/exercises/#{@exercise}/canonical-data.json")
     case response.status_code
     when 200
-      return JSON.parse(response.body)
+      return lowercase_keys(JSON.parse(response.body))
     when 404
       raise "Couldn't find canonical data for #{@exercise} on the github repo: problem-specifications."
     else
       raise "Error while requesting the #{@exercise} data file from GitHub... " +
             "Status was #{response.status_code}"
+    end
+  end
+
+  def lowercase_keys(obj)
+    if obj.as_h?
+      json_obj = {} of String => JSON::Any
+      obj.as_h.each do |key, value|
+        unless value == nil
+          json_obj[key.downcase] = lowercase_keys(value)
+        end
+      end
+      JSON::Any.new(json_obj)
+    elsif obj.as_a?
+      array = [] of JSON::Any
+      obj.as_a.each do |x|
+        array << lowercase_keys(x)
+      end
+      JSON::Any.new(array)
+    else
+      obj
     end
   end
 

--- a/bin/generator_help.cr
+++ b/bin/generator_help.cr
@@ -12,11 +12,13 @@ class GeneratorHelp
     @json.as_h["exercise_cammel"] = JSON::Any.new(to_cammel(@json["exercise"].to_s))
     additional_json()
     remove_tests(toml())
+    formated_json = lowercase_keys(@json)
     template_path = "./exercises/practice/#{@exercise}/.meta/test_template.liquid"
     raise "Template not found: #{template_path}" unless File.exists?(template_path)
     template_file = File.read(template_path)
     ctx = Liquid::Context.new
-    ctx.set "json", @json
+    ctx.set "json", formated_json
+    ctx.set "unformatted_json", @json
     tpl = Liquid::Template.parse template_file
     @tpl = tpl.render ctx
   end
@@ -60,7 +62,7 @@ class GeneratorHelp
     response = HTTP::Client.get("https://raw.githubusercontent.com/exercism/problem-specifications/main/exercises/#{@exercise}/canonical-data.json")
     case response.status_code
     when 200
-      return lowercase_keys(JSON.parse(response.body))
+      return JSON.parse(response.body)
     when 404
       raise "Couldn't find canonical data for #{@exercise} on the github repo: problem-specifications."
     else


### PR DESCRIPTION
Since the template engine doesn't support having uppercased keys so will the script convert all keys in JSON to lowercased.