### PR TITLE
fix the spec to match the text

### DIFF
--- a/exercises/concept/wellingtons-weather-station/.meta/src/exemplar.cr
+++ b/exercises/concept/wellingtons-weather-station/.meta/src/exemplar.cr
@@ -12,6 +12,6 @@ class Temperature
   end
 
   def number_missing_sensors(number_of_sensors)
-    4 - number_of_sensors % 4
+    (4 - number_of_sensors) % 4
   end
 end

--- a/exercises/concept/wellingtons-weather-station/spec/wellingtons_weather_station_spec.cr
+++ b/exercises/concept/wellingtons-weather-station/spec/wellingtons_weather_station_spec.cr
@@ -58,7 +58,7 @@ describe "Temprature" do
 
   describe "number_missing_sensors" do
     it "should return 0 if there are no missing sensors" do
-      Temperature.new.number_missing_sensors(4).should eq 4
+      Temperature.new.number_missing_sensors(4).should eq 0
     end
 
     it "should return 1 if there is one missing sensor" do


### PR DESCRIPTION
The specs text says it should be 0, but tests for 4, and to match the rest of the examples, and probably the expected solution given that there are 4 sensors, I think the text is correct. At least that's how I read it from the README.

This test does determine the difference if you want `(4 - number_of_sensors) % 4` to be the solution, or `4 - number_of_sensors % 4`

Although according to the [examplar](https://github.com/exercism/crystal/blob/c081fc279ccf5e7d438f74da0dd9d8aa51fe3a1b/exercises/concept/wellingtons-weather-station/.meta/src/exemplar.cr) you want the latter solution to match.

In which case the text should be updated.