### PR TITLE
Fix Isogram.isogram? declaration

### DIFF
--- a/exercises/practice/isogram/src/isogram.cr
+++ b/exercises/practice/isogram/src/isogram.cr
@@ -1,5 +1,5 @@
 module Isogram
-  def isogram?(phrase : String) : Bool
+  def self.isogram?(phrase : String) : Bool
     # Write your code for the 'Isogram' exercise in this file.
   end
 end


### PR DESCRIPTION
Because:
It is currently define as an instance method (Isogram#isogram?), which probably should be a class method judging from the spec.