### PR TITLE
Convert backtick (`) admonition fences to tildes (~)

### DIFF
--- a/concepts/bools/about.md
+++ b/concepts/bools/about.md
@@ -72,9 +72,9 @@ Since what is in parentheses is evaluated first, in the following example, the _
 # => true
 ```
 
-```exercism/note
+~~~~exercism/note
 You should only use parentheses when they affect the result, otherwise, should they be omitted.
-```
+~~~~
 
 ## Truthy and falsey
 

--- a/concepts/bools/introduction.md
+++ b/concepts/bools/introduction.md
@@ -72,9 +72,9 @@ Since what is in parentheses is evaluated first, in the following example, the _
 # => true
 ```
 
-```exercism/note
+~~~~exercism/note
 You should only use parentheses when they affect the result, otherwise, should they be omitted.
-```
+~~~~
 
 [bools]: https://crystal-lang.org/reference/latest/syntax_and_semantics/literals/bool.html
 [and]: https://crystal-lang.org/reference/latest/syntax_and_semantics/and.html

--- a/concepts/classes/about.md
+++ b/concepts/classes/about.md
@@ -42,7 +42,7 @@ end
 Account.new(4)
 ```
 
-````exercism/note
+~~~~exercism/note
 The `initialize` method cannot manually return a value, instead, `new` returns the newly created instance.
 
 ```crystal
@@ -55,7 +55,7 @@ end
 Account.new(4)
 # => #<Account:0x7f5dc33dcea0>
 ```
-````
+~~~~
 
 ## Instance methods
 

--- a/concepts/classes/introduction.md
+++ b/concepts/classes/introduction.md
@@ -42,7 +42,7 @@ end
 Account.new(4)
 ```
 
-````exercism/note
+~~~~exercism/note
 The `initialize` method cannot manually return a value, instead, `new` returns the newly created instance.
 
 ```crystal
@@ -55,7 +55,7 @@ end
 Account.new(4)
 # => #<Account:0x7f5dc33dcea0>
 ```
-````
+~~~~
 
 ## Instance methods
 

--- a/concepts/nil/about.md
+++ b/concepts/nil/about.md
@@ -68,10 +68,10 @@ This can be used to make if the value is `nil` it will be falsey and thereby the
 
 ## not_nil!
 
-```exercism/caution 
+~~~~exercism/caution 
 This approach should be seen as a last resort, and should only be used if you are **sure** that the value is not nil.
 If possible use the other approaches instead.
-```
+~~~~
 
 [`not_nil!`][not_nil] is a method that allows you to tell the compiler that a value is not nil and will thereby make so the type it holds can't be nil.
 It does that by raising an exception if the value is nil.

--- a/concepts/number-types/about.md
+++ b/concepts/number-types/about.md
@@ -94,7 +94,7 @@ Then `Float64` is more precise than Float32 and so on.
 
 ## Dig Deeper: unsigned integers vs signed integers
 
-```exercism/advanced
+~~~~exercism/advanced
 Under the hood, what differentiates unsigned and signed integers is that signed integers use the first bit to store the sign.
 The sign is either positive or negative.
 For unsigned integers, the first bit is used to store the value.
@@ -102,7 +102,7 @@ So for a signed 32-bit integer is the max value 2^31 - 1.
 For an unsigned 32-bit integer is the max value 2^32 - 1.
 
 If you are interested in learning more about signedness you can read more about it on [Wikipedia](https://en.wikipedia.org/wiki/Signedness).
-```
+~~~~
 
 [float]: https://crystal-lang.org/api/latest/Float.html
 [int]: https://crystal-lang.org/api/latest/Int.html

--- a/concepts/numbers/about.md
+++ b/concepts/numbers/about.md
@@ -68,7 +68,7 @@ The result will always be a Float.
 # => 2.0
 ```
 
-````exercism/caution
+~~~~exercism/caution
 In some programming languages when dividing by zero the result will be an error.
 
 In Crystal when dividing by zero the result will be `Infinity` or `-Infinity`.
@@ -85,7 +85,7 @@ Infinity and NaN are special values in the Float type.
 0 / 0
 # => NaN
 ```
-````
+~~~~
 
 ## Integer division
 
@@ -100,10 +100,10 @@ The result will always be rounded down to an Int.
 # => 2
 ```
 
-```exercism/caution
+~~~~exercism/caution
 When dividing by zero when using integer division results in a `DivisionByZeroError`.
 This is different from normal division.
-```
+~~~~
 
 ### Modulus
 
@@ -121,7 +121,7 @@ The `%` operator is used for modulus.
 # => 2
 ```
 
-````exercism/caution
+~~~~exercism/caution
 Dividing by zero when using modulo results in a DivisionByZeroError.
 This is different from normal division.
 
@@ -129,7 +129,7 @@ This is different from normal division.
 1 % 0
 # Error: Unhandled exception: Division by 0 (DivisionByZeroError)
 ```
-````
+~~~~
 
 ## Exponentiation
 

--- a/concepts/numbers/introduction.md
+++ b/concepts/numbers/introduction.md
@@ -68,7 +68,7 @@ The result will always be a Float.
 # => 2.0
 ```
 
-````exercism/caution
+~~~~exercism/caution
 In some programming languages when dividing by zero the result will be an error.
 
 In Crystal when dividing by zero the result will be `Infinity` or `-Infinity`.
@@ -85,7 +85,7 @@ Infinity and NaN are special values in the Float type.
 0 / 0
 # => NaN
 ```
-````
+~~~~
 
 ### Modulus
 
@@ -103,7 +103,7 @@ The `%` operator is used for modulus.
 # => 2
 ```
 
-````exercism/caution
+~~~~exercism/caution
 Dividing by zero when using modulo results in a DivisionByZeroError.
 This is different from normal division.
 
@@ -111,7 +111,7 @@ This is different from normal division.
 1 % 0
 # Error: Unhandled exception: Division by 0 (DivisionByZeroError)
 ```
-````
+~~~~
 
 ## Rounding
 

--- a/concepts/ranges/about.md
+++ b/concepts/ranges/about.md
@@ -18,7 +18,7 @@ Ranges can also be created using the `Range` initializer.
 Range.new(1, 5) # A range containing 1, 2, 3, 4, 5
 ```
 
-````exercism/note
+~~~~exercism/note
 When creating a range in Crystal using the range operators `..` or `...`, and wanting to call a method on the range, you need to wrap the range in parentheses.
 This is because the otherwise will the method be called on the 2nd argument of the range operator.
 
@@ -26,7 +26,7 @@ This is because the otherwise will the method be called on the 2nd argument of t
 (1..5).size # => 5
 1..5.size # => Error: undefined method 'size' for Int32
 ```
-````
+~~~~
 
 ## Getting substrings
 
@@ -69,9 +69,9 @@ Using beginless and endless ranges is useful when you want to, for example, slic
 "Hello World"[..5] # => "Hello"
 ```
 
-```exercism/caution
+~~~~exercism/caution
 If not used on a collection, the endless range can cause an endless sequence, if not used with caution.
-```
+~~~~
 
 ## Char ranges
 
@@ -94,7 +94,7 @@ Its behavior can become confusing when doing more complex string ranges, so use 
 
 ## Custom objects in ranges
 
-````exercism/advanced
+~~~~exercism/advanced
 Crystal allows you to use custom objects in ranges.
 The requirement for this is that the object implements the following:
 
@@ -125,7 +125,7 @@ end
 p (Foo.new(1)..Foo.new(5))
 # => #<Foo:0x7f3552bebe70 @value=1>, #<Foo:0x7f3552bebe50 @value=2>, #<Foo:0x7f3552bebe40 @value=3>, #<Foo:0x7f3552bebe30 @value=4>, #<Foo:0x7f3552bebe20 @value=5>
 ```
-````
+~~~~
 
 [range]: https://crystal-lang.org/api/latest/Range.html
 [sum]: https://crystal-lang.org/api/latest/Range.html#sum%28initial%29-instance-method

--- a/concepts/ranges/introduction.md
+++ b/concepts/ranges/introduction.md
@@ -18,7 +18,7 @@ Ranges can also be created using the `Range` initializer.
 Range.new(1, 5) # A range containing 1, 2, 3, 4, 5
 ```
 
-````exercism/note
+~~~~exercism/note
 When creating a range in Crystal using the range operators `..` or `...`, and wanting to call a method on the range, you need to wrap the range in parentheses.
 This is because the otherwise will the method be called on the 2nd argument of the range operator.
 
@@ -26,7 +26,7 @@ This is because the otherwise will the method be called on the 2nd argument of t
 (1..5).size # => 5
 1..5.size # => Error: undefined method 'size' for Int32
 ```
-````
+~~~~
 
 ## Getting substrings
 
@@ -69,9 +69,9 @@ Using beginless and endless ranges is useful when you want to, for example, slic
 "Hello World"[..5] # => "Hello"
 ```
 
-```exercism/caution
+~~~~exercism/caution
 If not used on a collection, the endless range can cause an endless sequence, if not used with caution.
-```
+~~~~
 
 ## Char ranges
 

--- a/concepts/return/about.md
+++ b/concepts/return/about.md
@@ -22,6 +22,6 @@ p speed_limit(2) # => 80
 p speed_limit(3) # => 100
 ```
 
-```exercism/note
+~~~~exercism/note
 The `return` keyword should be omitted when the last expression in a method is the value that should be returned.
-```
+~~~~

--- a/concepts/return/introduction.md
+++ b/concepts/return/introduction.md
@@ -23,6 +23,6 @@ p speed_limit(2) # => 80
 p speed_limit(3) # => 100
 ```
 
-```exercism/note
+~~~~exercism/note
 The `return` keyword should be omitted when the last expression in a method is the value that should be returned.
-```
+~~~~

--- a/concepts/strings/about.md
+++ b/concepts/strings/about.md
@@ -82,9 +82,9 @@ The size of a string is a stored property of the string, so it doesn't have to c
 Indexing is when you want to get a specific character from a string.
 To get a character from a string you can use familiar bracket notation.
 
-```exercism/note
+~~~~exercism/note
 `[]` is actually implemented as a String instance method, where the index is the method argument.
-```
+~~~~
 
 In Crystal is the first character in a string at index 0.
 

--- a/concepts/strings/introduction.md
+++ b/concepts/strings/introduction.md
@@ -82,9 +82,9 @@ The size of a string is a stored property of the string, so it doesn't have to c
 Indexing is when you want to get a specific character from a string.
 To get a character from a string you can use familiar bracket notation.
 
-```exercism/note
+~~~~exercism/note
 `[]` is actually implemented as a String instance method, where the index is the method argument.
-```
+~~~~
 
 In Crystal is the first character in a string at index 0.
 

--- a/concepts/union-type/about.md
+++ b/concepts/union-type/about.md
@@ -4,11 +4,11 @@ Crystal allows for a variable to consist of multiple types.
 This is called a [union type][union-type].
 In Crystal it is quite common for a union type to be inferred by the compiler.
 
-```exercism/note
+~~~~exercism/note
 A union type, even if it consists of multiple types, is still a single type at runtime.
 Meaning a union type is built of String and Int32 so it will not be both at the same time.
 Instead, it will be either a String or an Int32.
-```
+~~~~
 
 A union type is declared by separating the types with a pipe (`|`).
 They are often placed in parenthesis, but it is not required.
@@ -72,10 +72,10 @@ end
 This `is_a?` is not limited to having just a single type as an argument, but can have a union type as an argument.
 And can also be combined with `&&` to allow for multiple types.
 
-```exercism/note
+~~~~exercism/note
 The `is_a?` method when using it in conjunction with a control expression can't be an instance variable or class variable.
 Instead these have to be assigned to a local variable first.
-```
+~~~~
 
 ## as
 
@@ -91,11 +91,11 @@ a.as(String).downcase # => "hello"
 a.as(Int32) # Error: can't cast String to Int32
 ```
 
-```exercism/caution
+~~~~exercism/caution
 This approach is only meant for when you are sure that the type is the expected type or if you want to raise an exception when it is not.
 
 Using this approach with an improper setup can lead to unexpected behavior.
-```
+~~~~
 
 ## as?
 

--- a/concepts/union-type/introduction.md
+++ b/concepts/union-type/introduction.md
@@ -4,11 +4,11 @@ Crystal allows for a variable to consist of multiple types.
 This is called a [union type][union-type].
 In Crystal it is quite common for a union type to be inferred by the compiler.
 
-```exercism/note
+~~~~exercism/note
 A union type, even if it consists of multiple types, is still a single type at runtime.
 Meaning a union type is built of String and Int32 so it will not be both at the same time.
 Instead, it will be either a String or an Int32.
-```
+~~~~
 
 A union type is declared by separating the types with a pipe (`|`).
 They are often placed in parenthesis, but it is not required.
@@ -72,10 +72,10 @@ end
 This `is_a?` is not limited to having just a single type as an argument, but can have a union type as an argument.
 And can also be combined with `&&` to allow for multiple types.
 
-```exercism/note
+~~~~exercism/note
 The `is_a?` method when using it in conjunction with a control expression can't be an instance variable or class variable.
 Instead these have to be assigned to a local variable first.
-```
+~~~~
 
 ## as
 
@@ -91,11 +91,11 @@ a.as(String).downcase # => "hello"
 a.as(Int32) # Error: can't cast String to Int32
 ```
 
-```exercism/caution
+~~~~exercism/caution
 This approach is only meant for when you are sure that the type is the expected type or if you want to raise an exception when it is not.
 
 Using this approach with an improper setup can lead to unexpected behavior.
-```
+~~~~
 
 ## as?
 

--- a/exercises/concept/chess-game/.docs/introduction.md
+++ b/exercises/concept/chess-game/.docs/introduction.md
@@ -18,7 +18,7 @@ Ranges can also be created using the `Range` initializer.
 Range.new(1, 5) # A range containing 1, 2, 3, 4, 5
 ```
 
-````exercism/note
+~~~~exercism/note
 When creating a range in Crystal using the range operators `..` or `...`, and wanting to call a method on the range, you need to wrap the range in parentheses.
 This is because the otherwise will the method be called on the 2nd argument of the range operator.
 
@@ -26,7 +26,7 @@ This is because the otherwise will the method be called on the 2nd argument of t
 (1..5).size # => 5
 1..5.size # => Error: undefined method 'size' for Int32
 ```
-````
+~~~~
 
 ## Getting substrings
 
@@ -69,9 +69,9 @@ Using beginless and endless ranges is useful when you want to, for example, slic
 "Hello World"[..5] # => "Hello"
 ```
 
-```exercism/caution
+~~~~exercism/caution
 If not used on a collection, the endless range can cause an endless sequence, if not used with caution.
-```
+~~~~
 
 ## Char ranges
 

--- a/exercises/concept/crystal-hunter/.docs/introduction.md
+++ b/exercises/concept/crystal-hunter/.docs/introduction.md
@@ -72,9 +72,9 @@ Since what is in parentheses is evaluated first, in the following example, the _
 # => true
 ```
 
-```exercism/note
+~~~~exercism/note
 You should only use parentheses when they affect the result, otherwise, should they be omitted.
-```
+~~~~
 
 [bools]: https://crystal-lang.org/reference/latest/syntax_and_semantics/literals/bool.html
 [and]: https://crystal-lang.org/reference/latest/syntax_and_semantics/and.html

--- a/exercises/concept/interest-is-interesting/.docs/instructions.md
+++ b/exercises/concept/interest-is-interesting/.docs/instructions.md
@@ -53,9 +53,9 @@ SavingsAccount.years_before_desired_balance(balance, target_balance)
 # => 14
 ```
 
-```exercism/note
+~~~~exercism/note
 When applying simple interest to a principal balance, the balance is multiplied by the interest rate and the product of the two is the interest amount.
 
 Compound interest on the other hand is done by applying interest on a recurring basis.
 On each application the interest amount is computed and added to the principal balance so that subsequent interest calculations are subject to a greater principal balance.
-```
+~~~~

--- a/exercises/concept/interest-is-interesting/.docs/introduction.md
+++ b/exercises/concept/interest-is-interesting/.docs/introduction.md
@@ -148,9 +148,9 @@ p speed_limit(2) # => 80
 p speed_limit(3) # => 100
 ```
 
-```exercism/note
+~~~~exercism/note
 The `return` keyword should be omitted when the last expression in a method is the value that should be returned.
-```
+~~~~
 
 [while]: https://crystal-lang.org/reference/latest/syntax_and_semantics/while.html
 [until]: https://crystal-lang.org/reference/latest/syntax_and_semantics/until.html

--- a/exercises/concept/johannes-juice-maker/.docs/introduction.md
+++ b/exercises/concept/johannes-juice-maker/.docs/introduction.md
@@ -42,7 +42,7 @@ end
 Account.new(4)
 ```
 
-````exercism/note
+~~~~exercism/note
 The `initialize` method cannot manually return a value, instead, `new` returns the newly created instance.
 
 ```crystal
@@ -55,7 +55,7 @@ end
 Account.new(4)
 # => #<Account:0x7f5dc33dcea0>
 ```
-````
+~~~~
 
 ## Instance methods
 

--- a/exercises/concept/party-robot/.docs/introduction.md
+++ b/exercises/concept/party-robot/.docs/introduction.md
@@ -82,9 +82,9 @@ The size of a string is a stored property of the string, so it doesn't have to c
 Indexing is when you want to get a specific character from a string.
 To get a character from a string you can use familiar bracket notation.
 
-```exercism/note
+~~~~exercism/note
 `[]` is actually implemented as a String instance method, where the index is the method argument.
-```
+~~~~
 
 In Crystal is the first character in a string at index 0.
 

--- a/exercises/concept/password-lock/.docs/instructions.md
+++ b/exercises/concept/password-lock/.docs/instructions.md
@@ -5,10 +5,10 @@ The company you work for is just about to launch their brand new smartphone, cal
 The new processor has the power to be able to do more secure password handling than ever before, and the company has decided to use this to its advantage.
 They have asked you to implement a password lock system for the phone that will allow the user to set a password and then check if a given password is correct.
 
-```exercism/caution
+~~~~exercism/caution
 The password system practiced in this exercise is not secure and is only used for educational purposes.
 It should **NOT** be used in any real-world applications.
-```
+~~~~
 
 ## 1. Set a password
 

--- a/exercises/concept/password-lock/.docs/introduction.md
+++ b/exercises/concept/password-lock/.docs/introduction.md
@@ -4,11 +4,11 @@ Crystal allows for a variable to consist of multiple types.
 This is called a [union type][union-type].
 In Crystal it is quite common for a union type to be inferred by the compiler.
 
-```exercism/note
+~~~~exercism/note
 A union type, even if it consists of multiple types, is still a single type at runtime.
 Meaning a union type is built of String and Int32 so it will not be both at the same time.
 Instead, it will be either a String or an Int32.
-```
+~~~~
 
 A union type is declared by separating the types with a pipe (`|`).
 They are often placed in parenthesis, but it is not required.
@@ -72,10 +72,10 @@ end
 This `is_a?` is not limited to having just a single type as an argument, but can have a union type as an argument.
 And can also be combined with `&&` to allow for multiple types.
 
-```exercism/note
+~~~~exercism/note
 The `is_a?` method when using it in conjunction with a control expression can't be an instance variable or class variable.
 Instead these have to be assigned to a local variable first.
-```
+~~~~
 
 ## as
 
@@ -91,11 +91,11 @@ a.as(String).downcase # => "hello"
 a.as(Int32) # Error: can't cast String to Int32
 ```
 
-```exercism/caution
+~~~~exercism/caution
 This approach is only meant for when you are sure that the type is the expected type or if you want to raise an exception when it is not.
 
 Using this approach with an improper setup can lead to unexpected behavior.
-```
+~~~~
 
 ## as?
 

--- a/exercises/concept/wellingtons-weather-station/.docs/introduction.md
+++ b/exercises/concept/wellingtons-weather-station/.docs/introduction.md
@@ -68,7 +68,7 @@ The result will always be a Float.
 # => 2.0
 ```
 
-````exercism/caution
+~~~~exercism/caution
 In some programming languages when dividing by zero the result will be an error.
 
 In Crystal when dividing by zero the result will be `Infinity` or `-Infinity`.
@@ -85,7 +85,7 @@ Infinity and NaN are special values in the Float type.
 0 / 0
 # => NaN
 ```
-````
+~~~~
 
 ### Modulus
 
@@ -103,7 +103,7 @@ The `%` operator is used for modulus.
 # => 2
 ```
 
-````exercism/caution
+~~~~exercism/caution
 Dividing by zero when using modulo results in a DivisionByZeroError.
 This is different from normal division.
 
@@ -111,7 +111,7 @@ This is different from normal division.
 1 % 0
 # Error: Unhandled exception: Division by 0 (DivisionByZeroError)
 ```
-````
+~~~~
 
 ## Rounding
 


### PR DESCRIPTION
In line with Exercism's spec, we're ensuring that all admonition fences are demarcated with four tildes (`~~~~`) across all repositories. We will be following up with an org-wide script that can be used to keep this consistent. [Problem Specifications](https://github.com/exercism/problem-specifications) has already been updated.

We'll automatically merge this a week from now, but feel free to merge beforehand!

- Spec: https://exercism.org/docs/building/markdown/markdown#h-special-blocks-sometimes-called-admonitions
- Meta issue: https://github.com/exercism/exercism/issues/6705