### PR TITLE
[BlackJack]: Unify class method name

### DIFF
--- a/exercises/concept/blackjack/.docs/instructions.md
+++ b/exercises/concept/blackjack/.docs/instructions.md
@@ -18,11 +18,11 @@ You will receive two cards and will be able to see the face up card of the deale
 
 **Note**: Commonly, aces can take the value of 1 or 11 but for simplicity we will assume that they can only take the value of 11.
 
-Implement the method `Blackjack.card_value` which takes a card as a string as an argument.
+Implement the method `Blackjack.parse_value` which takes a card as a string as an argument.
 The method should return the value of the card as an integer.
 
 ```Crystal
-Blackjack.card_value("ace")
+Blackjack.parse_value("ace")
 # => 11
 ```
 

--- a/exercises/concept/blackjack/.docs/instructions.md
+++ b/exercises/concept/blackjack/.docs/instructions.md
@@ -18,11 +18,11 @@ You will receive two cards and will be able to see the face up card of the deale
 
 **Note**: Commonly, aces can take the value of 1 or 11 but for simplicity we will assume that they can only take the value of 11.
 
-Implement the method `Blackjack.parse_value` which takes a card as a string as an argument.
+Implement the method `Blackjack.parse_card` which takes a card as a string as an argument.
 The method should return the value of the card as an integer.
 
 ```Crystal
-Blackjack.parse_value("ace")
+Blackjack.parse_card("ace")
 # => 11
 ```
 

--- a/exercises/concept/blackjack/spec/blackjack_spec.cr
+++ b/exercises/concept/blackjack/spec/blackjack_spec.cr
@@ -7,7 +7,7 @@ describe Blackjack do
       Blackjack.parse_card("ace").should eq(11)
     end
 
-    it "pase two" do
+    it "parse two" do
       Blackjack.parse_card("two").should eq(2)
     end
 


### PR DESCRIPTION
Fix #511

This commit:
Change `BlackJack.card_value` to `BlackJack.parse_card` in instructions.md

This commit also:
Fix a typo in spec (pase -> parse)

PS:
Oops. Please ignore the first commit that change the `BlackJack.card_value` to `BlackJack.parse_value`. :P