### PR TITLE
two_bucket.cr: add missing `@` to parameter `moves`

### DIFF
--- a/exercises/practice/two-bucket/src/two_bucket.cr
+++ b/exercises/practice/two-bucket/src/two_bucket.cr
@@ -7,7 +7,7 @@ module TwoBucket
   struct Result
     property moves, other_bucket, goal_bucket
 
-    def initialize(moves : UInt32, @other_bucket : UInt32, @goal_bucket : Bucket)
+    def initialize(@moves : UInt32, @other_bucket : UInt32, @goal_bucket : Bucket)
     end
   end
 


### PR DESCRIPTION
The parameter should be the instance variable for sure.