### PR TITLE
Handle numerical issues complex_numbers_spec.cr

### DIFF
--- a/exercises/practice/complex-numbers/.meta/src/example.cr
+++ b/exercises/practice/complex-numbers/.meta/src/example.cr
@@ -59,10 +59,6 @@ class Complex
   def exp
     self.class.new(Math.exp(real), 0) * self.class.new(Math.cos(imaginary), Math.sin(imaginary))
   end
-
-  def ==(other : Complex)
-    (real - other.real).abs < 1e-9 && (imaginary - other.imaginary).abs < 1e-9
-  end
 end
 
 struct Number

--- a/exercises/practice/complex-numbers/.meta/test_template.ecr
+++ b/exercises/practice/complex-numbers/.meta/test_template.ecr
@@ -30,12 +30,13 @@ describe <%= to_capitalized(@json["exercise"].to_s).inspect %> do
         <%= status()%> "<%-= cases["description"] %>" do
             <% if cases["input"]["z"]? %>
                 Complex.new(<%= complex_args.call(cases["input"]["z"]) %>)<%= property_map["." + cases["property"].to_s] -%>
-                .should eq <% -%>
+                .should be_close <% -%>
                 <% if cases["expected"].as_a? -%>
                     Complex.new(<%= complex_args.call(cases["expected"]) %>)<% -%>
                 <% else -%>
                     <%= cases["expected"] -%>
                 <% end -%>
+                , 1e-9
             <% else %>
                 (<% -%>
                 <% if cases["input"]["z1"].as_a? -%>
@@ -49,12 +50,13 @@ describe <%= to_capitalized(@json["exercise"].to_s).inspect %> do
                     <% else -%>
                         <%= cases["input"]["z2"] -%><% -%>
                     <% end -%>
-                ).should eq<% -%>
+                ).should be_close<% -%>
                 <% if cases["expected"].as_a? -%>
                     Complex.new(<%= complex_args.call(cases["expected"]) %>)<% -%>
                 <% else -%>
                     <%= cases["expected"] -%>
                 <% end -%>
+                , 1e-9
             <% end %>
         end
     <% end %>

--- a/exercises/practice/complex-numbers/spec/complex_numbers_spec.cr
+++ b/exercises/practice/complex-numbers/spec/complex_numbers_spec.cr
@@ -3,162 +3,162 @@ require "../src/*"
 
 describe "ComplexNumbers" do
   it "Real part of a purely real number" do
-    Complex.new(1, 0).real.should eq 1
+    Complex.new(1, 0).real.should be_close 1, 1e-9
   end
 
   pending "Real part of a purely imaginary number" do
-    Complex.new(0, 1).real.should eq 0
+    Complex.new(0, 1).real.should be_close 0, 1e-9
   end
 
   pending "Real part of a number with real and imaginary part" do
-    Complex.new(1, 2).real.should eq 1
+    Complex.new(1, 2).real.should be_close 1, 1e-9
   end
 
   pending "Imaginary part of a purely real number" do
-    Complex.new(1, 0).imaginary.should eq 0
+    Complex.new(1, 0).imaginary.should be_close 0, 1e-9
   end
 
   pending "Imaginary part of a purely imaginary number" do
-    Complex.new(0, 1).imaginary.should eq 1
+    Complex.new(0, 1).imaginary.should be_close 1, 1e-9
   end
 
   pending "Imaginary part of a number with real and imaginary part" do
-    Complex.new(1, 2).imaginary.should eq 2
+    Complex.new(1, 2).imaginary.should be_close 2, 1e-9
   end
 
   pending "Imaginary unit" do
-    (Complex.new(0, 1) * Complex.new(0, 1)).should eq Complex.new(-1, 0)
+    (Complex.new(0, 1) * Complex.new(0, 1)).should be_close Complex.new(-1, 0), 1e-9
   end
 
   pending "Add purely real numbers" do
-    (Complex.new(1, 0) + Complex.new(2, 0)).should eq Complex.new(3, 0)
+    (Complex.new(1, 0) + Complex.new(2, 0)).should be_close Complex.new(3, 0), 1e-9
   end
 
   pending "Add purely imaginary numbers" do
-    (Complex.new(0, 1) + Complex.new(0, 2)).should eq Complex.new(0, 3)
+    (Complex.new(0, 1) + Complex.new(0, 2)).should be_close Complex.new(0, 3), 1e-9
   end
 
   pending "Add numbers with real and imaginary part" do
-    (Complex.new(1, 2) + Complex.new(3, 4)).should eq Complex.new(4, 6)
+    (Complex.new(1, 2) + Complex.new(3, 4)).should be_close Complex.new(4, 6), 1e-9
   end
 
   pending "Subtract purely real numbers" do
-    (Complex.new(1, 0) - Complex.new(2, 0)).should eq Complex.new(-1, 0)
+    (Complex.new(1, 0) - Complex.new(2, 0)).should be_close Complex.new(-1, 0), 1e-9
   end
 
   pending "Subtract purely imaginary numbers" do
-    (Complex.new(0, 1) - Complex.new(0, 2)).should eq Complex.new(0, -1)
+    (Complex.new(0, 1) - Complex.new(0, 2)).should be_close Complex.new(0, -1), 1e-9
   end
 
   pending "Subtract numbers with real and imaginary part" do
-    (Complex.new(1, 2) - Complex.new(3, 4)).should eq Complex.new(-2, -2)
+    (Complex.new(1, 2) - Complex.new(3, 4)).should be_close Complex.new(-2, -2), 1e-9
   end
 
   pending "Multiply purely real numbers" do
-    (Complex.new(1, 0) * Complex.new(2, 0)).should eq Complex.new(2, 0)
+    (Complex.new(1, 0) * Complex.new(2, 0)).should be_close Complex.new(2, 0), 1e-9
   end
 
   pending "Multiply purely imaginary numbers" do
-    (Complex.new(0, 1) * Complex.new(0, 2)).should eq Complex.new(-2, 0)
+    (Complex.new(0, 1) * Complex.new(0, 2)).should be_close Complex.new(-2, 0), 1e-9
   end
 
   pending "Multiply numbers with real and imaginary part" do
-    (Complex.new(1, 2) * Complex.new(3, 4)).should eq Complex.new(-5, 10)
+    (Complex.new(1, 2) * Complex.new(3, 4)).should be_close Complex.new(-5, 10), 1e-9
   end
 
   pending "Divide purely real numbers" do
-    (Complex.new(1, 0) / Complex.new(2, 0)).should eq Complex.new(0.5, 0)
+    (Complex.new(1, 0) / Complex.new(2, 0)).should be_close Complex.new(0.5, 0), 1e-9
   end
 
   pending "Divide purely imaginary numbers" do
-    (Complex.new(0, 1) / Complex.new(0, 2)).should eq Complex.new(0.5, 0)
+    (Complex.new(0, 1) / Complex.new(0, 2)).should be_close Complex.new(0.5, 0), 1e-9
   end
 
   pending "Divide numbers with real and imaginary part" do
-    (Complex.new(1, 2) / Complex.new(3, 4)).should eq Complex.new(0.44, 0.08)
+    (Complex.new(1, 2) / Complex.new(3, 4)).should be_close Complex.new(0.44, 0.08), 1e-9
   end
 
   pending "Absolute value of a positive purely real number" do
-    Complex.new(5, 0).abs.should eq 5
+    Complex.new(5, 0).abs.should be_close 5, 1e-9
   end
 
   pending "Absolute value of a negative purely real number" do
-    Complex.new(-5, 0).abs.should eq 5
+    Complex.new(-5, 0).abs.should be_close 5, 1e-9
   end
 
   pending "Absolute value of a purely imaginary number with positive imaginary part" do
-    Complex.new(0, 5).abs.should eq 5
+    Complex.new(0, 5).abs.should be_close 5, 1e-9
   end
 
   pending "Absolute value of a purely imaginary number with negative imaginary part" do
-    Complex.new(0, -5).abs.should eq 5
+    Complex.new(0, -5).abs.should be_close 5, 1e-9
   end
 
   pending "Absolute value of a number with real and imaginary part" do
-    Complex.new(3, 4).abs.should eq 5
+    Complex.new(3, 4).abs.should be_close 5, 1e-9
   end
 
   pending "Conjugate a purely real number" do
-    Complex.new(5, 0).conjugate.should eq Complex.new(5, 0)
+    Complex.new(5, 0).conjugate.should be_close Complex.new(5, 0), 1e-9
   end
 
   pending "Conjugate a purely imaginary number" do
-    Complex.new(0, 5).conjugate.should eq Complex.new(0, -5)
+    Complex.new(0, 5).conjugate.should be_close Complex.new(0, -5), 1e-9
   end
 
   pending "Conjugate a number with real and imaginary part" do
-    Complex.new(1, 1).conjugate.should eq Complex.new(1, -1)
+    Complex.new(1, 1).conjugate.should be_close Complex.new(1, -1), 1e-9
   end
 
   pending "Euler's identity/formula" do
-    Complex.new(0, Math::PI).exp.should eq Complex.new(-1, 0)
+    Complex.new(0, Math::PI).exp.should be_close Complex.new(-1, 0), 1e-9
   end
 
   pending "Exponential of 0" do
-    Complex.new(0, 0).exp.should eq Complex.new(1, 0)
+    Complex.new(0, 0).exp.should be_close Complex.new(1, 0), 1e-9
   end
 
   pending "Exponential of a purely real number" do
-    Complex.new(1, 0).exp.should eq Complex.new(Math::E, 0)
+    Complex.new(1, 0).exp.should be_close Complex.new(Math::E, 0), 1e-9
   end
 
   pending "Exponential of a number with real and imaginary part" do
-    Complex.new(Math.log(2), Math::PI).exp.should eq Complex.new(-2, 0)
+    Complex.new(Math.log(2), Math::PI).exp.should be_close Complex.new(-2, 0), 1e-9
   end
 
   pending "Exponential resulting in a number with real and imaginary part" do
-    Complex.new(Math.log(2)/2, Math::PI/4).exp.should eq Complex.new(1, 1)
+    Complex.new(Math.log(2)/2, Math::PI/4).exp.should be_close Complex.new(1, 1), 1e-9
   end
 
   pending "Add real number to complex number" do
-    (Complex.new(1, 2) + 5).should eq Complex.new(6, 2)
+    (Complex.new(1, 2) + 5).should be_close Complex.new(6, 2), 1e-9
   end
 
   pending "Add complex number to real number" do
-    (5 + Complex.new(1, 2)).should eq Complex.new(6, 2)
+    (5 + Complex.new(1, 2)).should be_close Complex.new(6, 2), 1e-9
   end
 
   pending "Subtract real number from complex number" do
-    (Complex.new(5, 7) - 4).should eq Complex.new(1, 7)
+    (Complex.new(5, 7) - 4).should be_close Complex.new(1, 7), 1e-9
   end
 
   pending "Subtract complex number from real number" do
-    (4 - Complex.new(5, 7)).should eq Complex.new(-1, -7)
+    (4 - Complex.new(5, 7)).should be_close Complex.new(-1, -7), 1e-9
   end
 
   pending "Multiply complex number by real number" do
-    (Complex.new(2, 5) * 5).should eq Complex.new(10, 25)
+    (Complex.new(2, 5) * 5).should be_close Complex.new(10, 25), 1e-9
   end
 
   pending "Multiply real number by complex number" do
-    (5 * Complex.new(2, 5)).should eq Complex.new(10, 25)
+    (5 * Complex.new(2, 5)).should be_close Complex.new(10, 25), 1e-9
   end
 
   pending "Divide complex number by real number" do
-    (Complex.new(10, 100) / 10).should eq Complex.new(1, 10)
+    (Complex.new(10, 100) / 10).should be_close Complex.new(1, 10), 1e-9
   end
 
   pending "Divide real number by complex number" do
-    (5 / Complex.new(1, 1)).should eq Complex.new(2.5, -2.5)
+    (5 / Complex.new(1, 1)).should be_close Complex.new(2.5, -2.5), 1e-9
   end
 end


### PR DESCRIPTION
The spec uses `eq` to test for equality of complex numbers. However, the real and imaginary parts are `Float64`, hence there might be numerical issues. Instead, the `be_close` expectation should be used.

Using `eq` would require the `Complex` class to be modified (e.g. by overloading `==` to be slightly imprecise). But this would somehow hard-code the precision of `Complex`, which would not be a good idea if `Complex` was a "production" implementation. Although it is only an exercise, it should not encourage "bad style" like this.