### PR TITLE
Adds test case for nil in resistor color

### DIFF
--- a/exercises/practice/resistor-color/spec/resistor_color_spec.cr
+++ b/exercises/practice/resistor-color/spec/resistor_color_spec.cr
@@ -1,24 +1,28 @@
 require "spec"
 require "../src/*"
 
-describe "ResistorColor" do
-  it "Black" do
-    ResistorColor.color_code("black").should eq(0)
+describe ResistorColor do
+  describe ".color_code" do
+    it "finds the value for black" do
+      ResistorColor.color_code("black").should eq(0)
+    end
+
+    pending "finds the value for white" do
+      ResistorColor.color_code("white").should eq(9)
+    end
+
+    pending "finds the value for orange" do
+      ResistorColor.color_code("orange").should eq(3)
+    end
+
+    pending "handles input that is not a recognised color" do
+      ResistorColor.color_code("Puce").should be_nil
+    end
   end
 
-  pending "White" do
-    ResistorColor.color_code("white").should eq(9)
-  end
-
-  pending "Orange" do
-    ResistorColor.color_code("orange").should eq(3)
-  end
-
-  pending "handles input that is not a recognised color" do
-    ResistorColor.color_code("Puce").should be_nil
-  end
-
-  pending "Colors" do
-    ResistorColor.colors.should eq(["black", "brown", "red", "orange", "yellow", "green", "blue", "violet", "grey", "white"])
+  describe ".colors" do
+    pending "returns an array of known colors" do
+      ResistorColor.colors.should eq(["black", "brown", "red", "orange", "yellow", "green", "blue", "violet", "grey", "white"])
+    end
   end
 end

--- a/exercises/practice/resistor-color/spec/resistor_color_spec.cr
+++ b/exercises/practice/resistor-color/spec/resistor_color_spec.cr
@@ -14,6 +14,10 @@ describe "ResistorColor" do
     ResistorColor.color_code("orange").should eq(3)
   end
 
+  pending "handles input that is not a recognised color" do
+    ResistorColor.color_code("Puce").should be_nil
+  end
+
   pending "Colors" do
     ResistorColor.colors.should eq(["black", "brown", "red", "orange", "yellow", "green", "blue", "violet", "grey", "white"])
   end


### PR DESCRIPTION
#### Context

When completing https://exercism.org/tracks/crystal/exercises/resistor-color , the signature for `def self.color_code(color : String) : Int32 | Nil` shows that the method can return `nil` but there's no spec to describe _why_.

#### Change

- Add test for nil return case
- Improve output for `crystal spec -v`

#### Considerations

0f100515 is not required but I think it improves the output.

<details>
  <summary>Before: `crystal spec -v `</summary>

```                      
ResistorColor
  Black
  White
  Orange
  handles input that is not a recognised color
  Colors

Pending:
  ResistorColor White
  ResistorColor Orange
  ResistorColor handles input that is not a recognised color
  ResistorColor Colors

Failures:

  1) ResistorColor Black
     Failure/Error: ResistorColor.color_code("black").should eq(0)

       Expected: 0
            got: nil

     # spec/resistor_color_spec.cr:6

Finished in 331 microseconds
5 examples, 1 failures, 0 errors, 4 pending

Failed examples:

crystal spec spec/resistor_color_spec.cr:5 # ResistorColor Black
```

</details>

<details>
  <summary>After `crystal spec -v`</summary>

```                          
ResistorColor
  .color_code
    finds the value for black
    finds the value for white
    finds the value for orange
    handles input that is not a recognised color
  .colors
    returns an array of known colors

Pending:
  ResistorColor .color_code finds the value for white
  ResistorColor .color_code finds the value for orange
  ResistorColor .color_code handles input that is not a recognised color
  ResistorColor .colors returns an array of known colors

Failures:

  1) ResistorColor .color_code finds the value for black
     Failure/Error: ResistorColor.color_code("black").should eq(0)

       Expected: 0
            got: nil

     # spec/resistor_color_spec.cr:7

Finished in 299 microseconds
5 examples, 1 failures, 0 errors, 4 pending

Failed examples:

crystal spec spec/resistor_color_spec.cr:6 # ResistorColor .color_code finds the value for black
```

</details>


