### PR TITLE
Add support for optional tests for reverse string

### DIFF
--- a/exercises/practice/reverse-string/.docs/instructions.append.md
+++ b/exercises/practice/reverse-string/.docs/instructions.append.md
@@ -1,0 +1,6 @@
+# Instructions append
+
+The Crystal track add optional test to test to test possible letters to be any unicode character, not just ASCII alphabetic ones.
+These are not accesaible from the web editor, but is default when exectued locally.
+
+To disable these tests, when calling the test runner, add the following flag: `--tag "~optional"`

--- a/exercises/practice/reverse-string/.docs/instructions.append.md
+++ b/exercises/practice/reverse-string/.docs/instructions.append.md
@@ -1,6 +1,6 @@
 # Instructions append
 
-The Crystal track add optional test to test to test possible letters to be any unicode character, not just ASCII alphabetic ones.
-These are not accesaible from the web editor, but is default when exectued locally.
+An optional test has been added that tests for possible letters to be any unicode character, not just ASCII alphabetic ones.
+These are not accessible from the web editor, but are run by default when executed locally.
 
-To disable these tests, when calling the test runner, add the following flag: `--tag "~optional"`
+To disable these tests, when calling the test command (`crystal spec`), add the following flag: `--tag "~optional"`

--- a/exercises/practice/reverse-string/.meta/test_template.ecr
+++ b/exercises/practice/reverse-string/.meta/test_template.ecr
@@ -5,12 +5,10 @@ describe "<%-= to_capitalized(@json["exercise"].to_s) %>" do
 <%- @json["cases"].as_a.each do |cases| %>
     <%- if cases["scenarios"]? %>
         <%= status()%> "<%-= cases["description"] %>", tags: "optional" do
-        <%= to_capitalized(@json["exercise"].to_s) %>.<%= cases["property"].to_s.underscore %>("<%= cases["input"]["value"] %>").should eq("<%= cases["expected"] %>")
-    end
     <%- else %>
-    <%= status()%> "<%-= cases["description"] %>" do
-        <%= to_capitalized(@json["exercise"].to_s) %>.<%= cases["property"].to_s.underscore %>("<%= cases["input"]["value"] %>").should eq("<%= cases["expected"] %>")
-    end
+        <%= status()%> "<%-= cases["description"] %>" do
     <%- end %>
+    <%= to_capitalized(@json["exercise"].to_s) %>.<%= cases["property"].to_s.underscore %>("<%= cases["input"]["value"] %>").should eq("<%= cases["expected"] %>")
+    end
 <% end %>
 end

--- a/exercises/practice/reverse-string/.meta/test_template.ecr
+++ b/exercises/practice/reverse-string/.meta/test_template.ecr
@@ -3,8 +3,14 @@ require "../src/*"
 
 describe "<%-= to_capitalized(@json["exercise"].to_s) %>" do
 <%- @json["cases"].as_a.each do |cases| %>
+    <%- if cases["scenarios"]? %>
+        <%= status()%> "<%-= cases["description"] %>", tags: "optional" do
+        <%= to_capitalized(@json["exercise"].to_s) %>.<%= cases["property"].to_s.underscore %>("<%= cases["input"]["value"] %>").should eq("<%= cases["expected"] %>")
+    end
+    <%- else %>
     <%= status()%> "<%-= cases["description"] %>" do
         <%= to_capitalized(@json["exercise"].to_s) %>.<%= cases["property"].to_s.underscore %>("<%= cases["input"]["value"] %>").should eq("<%= cases["expected"] %>")
     end
+    <%- end %>
 <% end %>
 end

--- a/exercises/practice/reverse-string/.meta/tests.toml
+++ b/exercises/practice/reverse-string/.meta/tests.toml
@@ -29,12 +29,9 @@ description = "an even-sized word"
 
 [1bed0f8a-13b0-4bd3-9d59-3d0593326fa2]
 description = "wide characters"
-include = false
 
 [93d7e1b8-f60f-4f3c-9559-4056e10d2ead]
 description = "grapheme cluster with pre-combined form"
-include = false
 
 [1028b2c1-6763-4459-8540-2da47ca512d9]
 description = "grapheme clusters"
-include = false

--- a/exercises/practice/reverse-string/spec/reverse_string_spec.cr
+++ b/exercises/practice/reverse-string/spec/reverse_string_spec.cr
@@ -25,4 +25,16 @@ describe "ReverseString" do
   pending "an even-sized word" do
     ReverseString.reverse("drawer").should eq("reward")
   end
+
+  pending "wide characters", tags: "optional" do
+    ReverseString.reverse("子猫").should eq("猫子")
+  end
+
+  pending "grapheme cluster with pre-combined form", tags: "optional" do
+    ReverseString.reverse("Würstchenstand").should eq("dnatsnehctsrüW")
+  end
+
+  pending "grapheme clusters", tags: "optional" do
+    ReverseString.reverse("ผู้เขียนโปรแกรม").should eq("มรกแรปโนยขีเผู้")
+  end
 end


### PR DESCRIPTION
This pr is dependent on the 2.1 update for the test runner ~~and documentation about tags is also missing~~.