### PR TITLE
Add test to dominoes checking proper reversing

### DIFF
--- a/exercises/practice/dominoes/spec/dominoes_spec.cr
+++ b/exercises/practice/dominoes/spec/dominoes_spec.cr
@@ -22,6 +22,10 @@ describe "Dominoes" do
     Dominoes.can_chain([[1, 2], [1, 3], [2, 3]]).should eq(true)
   end
 
+  pending "if a domino is reversed it cannot be used the unreversed way" do
+    Dominoes.can_chain([[1, 2], [3, 2]]).should eq(false)
+  end
+
   pending "can't be chained" do
     Dominoes.can_chain([[1, 2], [4, 1], [2, 3]]).should eq(false)
   end


### PR DESCRIPTION
I was mentoring a student and they submitted an implementation that passed all tests but was still not correct. In essence it allowed to use a domino in its reversed and unreversed form at the same time by only checking if one of the 2 positions matched any of the two other ones. While this would make the existing test fail, checking that `[1,2]` is not chainable, they also handled the case of only one domino separately, so this test actually passed.

In this PR I add another test that shall check if reversing is handled properly. The two dominoes `[1, 2], [3, 2]` are not chainable according to the exercise description.
(The solution submitted by the student fails on this test as expected.)