### PR TITLE
fix: A typo in the class name

### DIFF
--- a/concepts/conditionals/about.md
+++ b/concepts/conditionals/about.md
@@ -83,7 +83,7 @@ end
 The `else` statement can be used in conjunction with the `if` and `unless` statements.
 The `else` statement will be executed if the `if` branch or the `unless` branch is not executed.
 
-~~~~exercism/warrning
+~~~~exercism/warning
 Even though an `else` branch can be used in conjunction with `unless,` it is discouraged to do so because it hurts readability.
 Instead, using `if !condition` with an else branch is recommended.
 ~~~~

--- a/concepts/conditionals/introduction.md
+++ b/concepts/conditionals/introduction.md
@@ -70,7 +70,7 @@ end
 The `else` statement can be used in conjunction with the `if` and `unless` statements.
 The `else` statement will be executed if the `if` branch or the `unless` branch is not executed.
 
-~~~~exercism/warrning
+~~~~exercism/warning
 Even though an `else` branch can be used in conjunction with `unless,` it is discouraged to do so because it hurts readability.
 Instead, using `if !condition` with an else branch is recommended.
 ~~~~

--- a/exercises/concept/meltdown-mitigation/.docs/introduction.md
+++ b/exercises/concept/meltdown-mitigation/.docs/introduction.md
@@ -70,7 +70,7 @@ end
 The `else` statement can be used in conjunction with the `if` and `unless` statements.
 The `else` statement will be executed if the `if` branch or the `unless` branch is not executed.
 
-~~~~exercism/warrning
+~~~~exercism/warning
 Even though an `else` branch can be used in conjunction with `unless,` it is discouraged to do so because it hurts readability.
 Instead, using `if !condition` with an else branch is recommended.
 ~~~~


### PR DESCRIPTION
Wrong class name `exercism/warrning`