### PR TITLE
Baffling Birthdays - Reduce the odds of a false failure

### DIFF
--- a/exercises/practice/baffling-birthdays/.meta/src/example.cr
+++ b/exercises/practice/baffling-birthdays/.meta/src/example.cr
@@ -24,6 +24,6 @@ class BafflingBirthdays
   end
 
   def self.estimated_probability_of_shared_birthday(size : Int) : Float
-    return (1..10000).sum { |_| shared_birthday(random_birthdates(size)) ? 1 : 0 } / 100.0
+    return (1..100000).sum { |_| shared_birthday(random_birthdates(size)) ? 1 : 0 } / 1000.0
   end
 end

--- a/exercises/practice/baffling-birthdays/.meta/test_template.ecr
+++ b/exercises/practice/baffling-birthdays/.meta/test_template.ecr
@@ -19,10 +19,10 @@ describe "<%-= to_capitalized(@json["exercise"].to_s) %>" do
             result = <%= to_capitalized(@json["exercise"].to_s) %>.<%= sub_case["property"].to_s.underscore %>(50)
             result.all? { |date| Time.leap_year?(date.year) }.should be_false
         <%- elsif (sub_case["expected"]["months"]? || {} of String => Bool)["random"]? -%>
-            result = <%= to_capitalized(@json["exercise"].to_s) %>.<%= sub_case["property"].to_s.underscore %>(100)
+            result = <%= to_capitalized(@json["exercise"].to_s) %>.<%= sub_case["property"].to_s.underscore %>(300)
             result.to_set { |date| date.month }.size.should eq(12)
         <%- elsif (sub_case["expected"]["days"]? || {} of String => Bool)["random"]? -%>
-            result = <%= to_capitalized(@json["exercise"].to_s) %>.<%= sub_case["property"].to_s.underscore %>(300)
+            result = <%= to_capitalized(@json["exercise"].to_s) %>.<%= sub_case["property"].to_s.underscore %>(1000)
             result.to_set { |date| date.day }.size.should eq(31)
         <% end %>
     end

--- a/exercises/practice/baffling-birthdays/spec/baffling_birthdays_spec.cr
+++ b/exercises/practice/baffling-birthdays/spec/baffling_birthdays_spec.cr
@@ -69,12 +69,12 @@ describe "BafflingBirthdays" do
   end
 
   pending "months are random" do
-    result = BafflingBirthdays.random_birthdates(100)
+    result = BafflingBirthdays.random_birthdates(300)
     result.to_set { |date| date.month }.size.should eq(12)
   end
 
   pending "days are random" do
-    result = BafflingBirthdays.random_birthdates(300)
+    result = BafflingBirthdays.random_birthdates(1000)
     result.to_set { |date| date.day }.size.should eq(31)
   end
 


### PR DESCRIPTION
After merging Baffling Birthdays, there was a false failure in CI:
https://github.com/exercism/crystal/actions/runs/24695605912