### PR TITLE
Format all `instructions.append.md` to start with an H1 (required but ignored) and H2

### DIFF
--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions append
 
+## Implementation
+
 The Crystal track add optional test to test possible letters to be any Unicode character, not just ASCII alphabetic ones.
 These are not accessible from the web editor, but is default when exectued locally.
 

--- a/exercises/practice/book-store/.docs/instructions.append.md
+++ b/exercises/practice/book-store/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 ## More on price per book
 
 Because the problem specification prohibits prices in float representation, the actual price per book is in cents (800¢) instead of dollars ($8).

--- a/exercises/practice/complex-numbers/.docs/instructions.append.md
+++ b/exercises/practice/complex-numbers/.docs/instructions.append.md
@@ -1,3 +1,7 @@
+# Instructions append
+
+## Implementation
+
 In this exercise you will need to add methods to an existing struct (`Number`).
 You can see an example of this in the Crystal documentation for [getters and setters][getters-and-setters]
 

--- a/exercises/practice/leap/.docs/instructions.append.md
+++ b/exercises/practice/leap/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Introduction append
 
+## Implementation
+
 There are various ways to solve **leap**, this exercise focuses on not using the built-in `Time.leap_year?` method.
 This is because the goal of this exercise is to learn about dealing with comparisons and boolean logic.
 But for any other purpose, it is recommended to use the built-in method.

--- a/exercises/practice/parallel-letter-frequency/.docs/instructions.append.md
+++ b/exercises/practice/parallel-letter-frequency/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instruction Appendix
 
+## Implementation
+
 For building a concurrent/parallel program in Crystal, [might this resource prove useful][resource].
 In Crystal 1.19 a new [Sync][sync] library was added which adds several primitives to make it easier to make high performance concurrent/parallel programs.
 

--- a/exercises/practice/reverse-string/.docs/instructions.append.md
+++ b/exercises/practice/reverse-string/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions append
 
+## Implementation
+
 An optional test has been added that tests for possible letters to be any unicode character, not just ASCII alphabetic ones.
 These are not accessible from the web editor, but are run by default when executed locally.
 

--- a/exercises/practice/roman-numerals/.docs/instructions.append.md
+++ b/exercises/practice/roman-numerals/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 ## Adding method to the Int struct
 
 This exercise focuses on adding methods to the `Int` struct in Crystal.

--- a/exercises/practice/state-of-tic-tac-toe/.docs/instructions.append.md
+++ b/exercises/practice/state-of-tic-tac-toe/.docs/instructions.append.md
@@ -1,3 +1,7 @@
+# Instructions append
+
+## Implementation
+
 In this exercise you are given 2 enums.
 Both enum types are to be used as return values for the `state` method via a union.
 You can read more about enums and unions in the Crystal reference documentation:

--- a/exercises/practice/strain/.docs/introduction.append.md
+++ b/exercises/practice/strain/.docs/introduction.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 ## Adding methods to the Array class
 
 This exercise focuses on adding methods to the `Array` class in Crystal.

--- a/exercises/practice/yacht/.docs/instructions.append.md
+++ b/exercises/practice/yacht/.docs/instructions.append.md
@@ -1,3 +1,7 @@
+# Instructions append
+
+## Implementation
+
 In this exercise one of the arguments is an enum.
 You can read more about enums in the Crystal reference documentation:
 - [enum][enum]


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.